### PR TITLE
Remove 'copy genesis.json' from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN rustup target add wasm32-unknown-unknown
 # Copy source code
 COPY node ./node
 COPY runtime ./runtime
-COPY Cargo.lock Cargo.toml genesis.json ./
+COPY Cargo.lock Cargo.toml ./
 
 
 


### PR DESCRIPTION
## Description

Remove 'copy genesis.json' from Dockerfile

## Motivation

In previous changes was missed to remove this copy command from Dockerfile leading up to errors building the docker image

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Impact on the project

Dockerfile 
