### PR TITLE
feat: cargo scripts

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,10 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[config]
+default_to_workspace = false
+
+[tasks.alphanet-dev]
+script = [
+    "cargo run --release -- --dev --unsafe-rpc-external --rpc-cors all --unsafe-ws-external"
+]


### PR DESCRIPTION
## Description

I've added a Makefile.toml file (default filename) that is used by `cargo-make` for reading the available scripts in the project.

## Motivation

For simplifying development experience and unifying the exact blockchain configuration that all developers are working on.

## Impact on the project

Doesn't affect to the project itself just simplifies the way we 

## Additional context

For using, cargo-make you have to install it with:

```
cargo install --force cargo-make
```
