### PR TITLE
Fix failing calls to precompile contracts from other smart contracts. 

### DIFF
--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -38,154 +38,154 @@ use crate::client::Client;
 ///
 /// Note: Should only be used for benchmarking.
 pub struct RemarkBuilder {
-    client: Arc<Client>,
+	client: Arc<Client>,
 }
 
 impl RemarkBuilder {
-    /// Creates a new [`Self`] from the given client.
-    pub fn new(client: Arc<Client>) -> Self {
-        Self { client }
-    }
+	/// Creates a new [`Self`] from the given client.
+	pub fn new(client: Arc<Client>) -> Self {
+		Self { client }
+	}
 }
 
 impl frame_benchmarking_cli::ExtrinsicBuilder for RemarkBuilder {
-    fn pallet(&self) -> &str {
-        "system"
-    }
+	fn pallet(&self) -> &str {
+		"system"
+	}
 
-    fn extrinsic(&self) -> &str {
-        "remark"
-    }
+	fn extrinsic(&self) -> &str {
+		"remark"
+	}
 
-    fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
-        let acc = Sr25519Keyring::Bob.pair();
-        let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
-            self.client.as_ref(),
-            acc,
-            SystemCall::remark { remark: vec![] }.into(),
-            nonce,
-        )
-        .into();
+	fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
+		let acc = Sr25519Keyring::Bob.pair();
+		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
+			self.client.as_ref(),
+			acc,
+			SystemCall::remark { remark: vec![] }.into(),
+			nonce,
+		)
+		.into();
 
-        Ok(extrinsic)
-    }
+		Ok(extrinsic)
+	}
 }
 
 /// Generates `Balances::TransferKeepAlive` extrinsics for the benchmarks.
 ///
 /// Note: Should only be used for benchmarking.
 pub struct TransferKeepAliveBuilder {
-    client: Arc<Client>,
-    dest: AccountId,
-    value: Balance,
+	client: Arc<Client>,
+	dest: AccountId,
+	value: Balance,
 }
 
 impl TransferKeepAliveBuilder {
-    /// Creates a new [`Self`] from the given client.
-    pub fn new(client: Arc<Client>, dest: AccountId, value: Balance) -> Self {
-        Self {
-            client,
-            dest,
-            value,
-        }
-    }
+	/// Creates a new [`Self`] from the given client.
+	pub fn new(client: Arc<Client>, dest: AccountId, value: Balance) -> Self {
+		Self {
+			client,
+			dest,
+			value,
+		}
+	}
 }
 
 impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
-    fn pallet(&self) -> &str {
-        "balances"
-    }
+	fn pallet(&self) -> &str {
+		"balances"
+	}
 
-    fn extrinsic(&self) -> &str {
-        "transfer_keep_alive"
-    }
+	fn extrinsic(&self) -> &str {
+		"transfer_keep_alive"
+	}
 
-    fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
-        let acc = Sr25519Keyring::Bob.pair();
-        let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
-            self.client.as_ref(),
-            acc,
-            BalancesCall::transfer_keep_alive {
-                dest: self.dest.clone().into(),
-                value: self.value,
-            }
-            .into(),
-            nonce,
-        )
-        .into();
+	fn build(&self, nonce: u32) -> std::result::Result<OpaqueExtrinsic, &'static str> {
+		let acc = Sr25519Keyring::Bob.pair();
+		let extrinsic: OpaqueExtrinsic = create_benchmark_extrinsic(
+			self.client.as_ref(),
+			acc,
+			BalancesCall::transfer_keep_alive {
+				dest: self.dest.clone().into(),
+				value: self.value,
+			}
+			.into(),
+			nonce,
+		)
+		.into();
 
-        Ok(extrinsic)
-    }
+		Ok(extrinsic)
+	}
 }
 
 /// Create a transaction using the given `call`.
 ///
 /// Note: Should only be used for benchmarking.
 pub fn create_benchmark_extrinsic(
-    client: &Client,
-    sender: sr25519::Pair,
-    call: runtime::RuntimeCall,
-    nonce: u32,
+	client: &Client,
+	sender: sr25519::Pair,
+	call: runtime::RuntimeCall,
+	nonce: u32,
 ) -> runtime::UncheckedExtrinsic {
-    let genesis_hash = client
-        .block_hash(0)
-        .ok()
-        .flatten()
-        .expect("Genesis block exists; qed");
-    let best_hash = client.chain_info().best_hash;
-    let best_block = client.chain_info().best_number;
+	let genesis_hash = client
+		.block_hash(0)
+		.ok()
+		.flatten()
+		.expect("Genesis block exists; qed");
+	let best_hash = client.chain_info().best_hash;
+	let best_block = client.chain_info().best_number;
 
-    let period = runtime::BlockHashCount::get()
-        .checked_next_power_of_two()
-        .map(|c| c / 2)
-        .unwrap_or(2) as u64;
-    let extra: runtime::SignedExtra = (
-        frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
-        frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
-        frame_system::CheckTxVersion::<runtime::Runtime>::new(),
-        frame_system::CheckGenesis::<runtime::Runtime>::new(),
-        frame_system::CheckMortality::<runtime::Runtime>::from(Era::mortal(
-            period,
-            best_block.saturated_into(),
-        )),
-        frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
-        frame_system::CheckWeight::<runtime::Runtime>::new(),
-        pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
-    );
+	let period = runtime::BlockHashCount::get()
+		.checked_next_power_of_two()
+		.map(|c| c / 2)
+		.unwrap_or(2) as u64;
+	let extra: runtime::SignedExtra = (
+		frame_system::CheckNonZeroSender::<runtime::Runtime>::new(),
+		frame_system::CheckSpecVersion::<runtime::Runtime>::new(),
+		frame_system::CheckTxVersion::<runtime::Runtime>::new(),
+		frame_system::CheckGenesis::<runtime::Runtime>::new(),
+		frame_system::CheckMortality::<runtime::Runtime>::from(Era::mortal(
+			period,
+			best_block.saturated_into(),
+		)),
+		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
+		frame_system::CheckWeight::<runtime::Runtime>::new(),
+		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
+	);
 
-    let raw_payload = runtime::SignedPayload::from_raw(
-        call.clone(),
-        extra.clone(),
-        (
-            (),
-            runtime::VERSION.spec_version,
-            runtime::VERSION.transaction_version,
-            genesis_hash,
-            best_hash,
-            (),
-            (),
-            (),
-        ),
-    );
-    let signature = raw_payload.using_encoded(|e| sender.sign(e));
+	let raw_payload = runtime::SignedPayload::from_raw(
+		call.clone(),
+		extra.clone(),
+		(
+			(),
+			runtime::VERSION.spec_version,
+			runtime::VERSION.transaction_version,
+			genesis_hash,
+			best_hash,
+			(),
+			(),
+			(),
+		),
+	);
+	let signature = raw_payload.using_encoded(|e| sender.sign(e));
 
-    runtime::UncheckedExtrinsic::new_signed(
-        call,
-        AccountId32::from(sender.public()).into(),
-        runtime::Signature::Sr25519(signature),
-        extra,
-    )
+	runtime::UncheckedExtrinsic::new_signed(
+		call,
+		AccountId32::from(sender.public()).into(),
+		runtime::Signature::Sr25519(signature),
+		extra,
+	)
 }
 
 /// Generates inherent data for the `benchmark overhead` command.
 ///
 /// Note: Should only be used for benchmarking.
 pub fn inherent_benchmark_data() -> Result<InherentData> {
-    let mut inherent_data = InherentData::new();
-    let d = Duration::from_millis(0);
-    let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
+	let mut inherent_data = InherentData::new();
+	let d = Duration::from_millis(0);
+	let timestamp = sp_timestamp::InherentDataProvider::new(d.into());
 
-    futures::executor::block_on(timestamp.provide_inherent_data(&mut inherent_data))
-        .map_err(|e| format!("creating inherent data: {:?}", e))?;
-    Ok(inherent_data)
+	futures::executor::block_on(timestamp.provide_inherent_data(&mut inherent_data))
+		.map_err(|e| format!("creating inherent data: {:?}", e))?;
+	Ok(inherent_data)
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -23,28 +23,28 @@ pub type DevChainSpec = sc_service::GenericChainSpec<DevGenesisExt>;
 /// Extension for the dev genesis config to support a custom changes to the genesis state.
 #[derive(Serialize, Deserialize)]
 pub struct DevGenesisExt {
-    /// Genesis config.
-    genesis_config: GenesisConfig,
-    /// The flag that if enable manual-seal mode.
-    enable_manual_seal: Option<bool>,
+	/// Genesis config.
+	genesis_config: GenesisConfig,
+	/// The flag that if enable manual-seal mode.
+	enable_manual_seal: Option<bool>,
 }
 
 impl sp_runtime::BuildStorage for DevGenesisExt {
-    fn assimilate_storage(&self, storage: &mut Storage) -> Result<(), String> {
-        BasicExternalities::execute_with_storage(storage, || {
-            if let Some(enable_manual_seal) = &self.enable_manual_seal {
-                EnableManualSeal::set(enable_manual_seal);
-            }
-        });
-        self.genesis_config.assimilate_storage(storage)
-    }
+	fn assimilate_storage(&self, storage: &mut Storage) -> Result<(), String> {
+		BasicExternalities::execute_with_storage(storage, || {
+			if let Some(enable_manual_seal) = &self.enable_manual_seal {
+				EnableManualSeal::set(enable_manual_seal);
+			}
+		});
+		self.genesis_config.assimilate_storage(storage)
+	}
 }
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
+	TPublic::Pair::from_string(&format!("//{}", seed), None)
+		.expect("static values are valid; qed")
+		.public()
 }
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -52,290 +52,290 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
 {
-    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
 /// Generate an Aura authority key.
 pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
-    (get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
+	(get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
 fn get_key_sr(pubkey: &str) -> sr25519::Public {
-    match sr25519::Public::from_str(pubkey) {
-        Ok(sr_pubkey) => sr_pubkey,
-        Err(_) => panic!("sr pubkey bad formatted"),
-    }
+	match sr25519::Public::from_str(pubkey) {
+		Ok(sr_pubkey) => sr_pubkey,
+		Err(_) => panic!("sr pubkey bad formatted"),
+	}
 }
 
 fn get_authority_from_pubkeys(sr_pubkey: &str, ed_pubkey: &str) -> (AuraId, GrandpaId) {
-    (
-        AuraId::from_string(sr_pubkey).expect("bad formatted sr pubkey"),
-        GrandpaId::from_string(ed_pubkey).expect("bad formatted ed pubkey"),
-    )
+	(
+		AuraId::from_string(sr_pubkey).expect("bad formatted sr pubkey"),
+		GrandpaId::from_string(ed_pubkey).expect("bad formatted ed pubkey"),
+	)
 }
 
 pub fn development_config(enable_manual_seal: Option<bool>) -> DevChainSpec {
-    let wasm_binary = WASM_BINARY.expect("WASM not available");
+	let wasm_binary = WASM_BINARY.expect("WASM not available");
 
-    DevChainSpec::from_genesis(
-        // Name
-        "Development",
-        // ID
-        "dev",
-        ChainType::Development,
-        move || {
-            DevGenesisExt {
-                genesis_config: testnet_genesis(
-                    wasm_binary,
-                    // Sudo account
-                    // Pre-funded accounts
-                    vec![
-                        get_account_id_from_seed::<sr25519::Public>("Alice"),
-                        get_account_id_from_seed::<sr25519::Public>("Bob"),
-                        get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                        get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    ],
-                    // Initial PoA authorities
-                    vec![authority_keys_from_seed("Alice")],
-                    vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-                    42,
-                ),
-                enable_manual_seal,
-            }
-        },
-        // Bootnodes
-        vec![],
-        // Telemetry
-        None,
-        // Protocol ID
-        None,
-        None,
-        // Properties
-        None,
-        // Extensions
-        None,
-    )
+	DevChainSpec::from_genesis(
+		// Name
+		"Development",
+		// ID
+		"dev",
+		ChainType::Development,
+		move || {
+			DevGenesisExt {
+				genesis_config: testnet_genesis(
+					wasm_binary,
+					// Sudo account
+					// Pre-funded accounts
+					vec![
+						get_account_id_from_seed::<sr25519::Public>("Alice"),
+						get_account_id_from_seed::<sr25519::Public>("Bob"),
+						get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+						get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					],
+					// Initial PoA authorities
+					vec![authority_keys_from_seed("Alice")],
+					vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
+					42,
+				),
+				enable_manual_seal,
+			}
+		},
+		// Bootnodes
+		vec![],
+		// Telemetry
+		None,
+		// Protocol ID
+		None,
+		None,
+		// Properties
+		None,
+		// Extensions
+		None,
+	)
 }
 
 pub fn local_testnet_config() -> ChainSpec {
-    let wasm_binary = WASM_BINARY.expect("WASM not available");
+	let wasm_binary = WASM_BINARY.expect("WASM not available");
 
-    ChainSpec::from_genesis(
-        // Name
-        "Local Testnet",
-        // ID
-        "local_testnet",
-        ChainType::Local,
-        move || {
-            testnet_genesis(
-                wasm_binary,
-                // Initial PoA authorities
-                // Pre-funded accounts
-                vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-                ],
-                vec![
-                    authority_keys_from_seed("Alice"),
-                    authority_keys_from_seed("Bob"),
-                ],
-                vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                ],
-                20180427,
-            )
-        },
-        // Bootnodes
-        vec![],
-        // Telemetry
-        None,
-        // Protocol ID
-        None,
-        None,
-        // Properties
-        None,
-        // Extensions
-        None,
-    )
+	ChainSpec::from_genesis(
+		// Name
+		"Local Testnet",
+		// ID
+		"local_testnet",
+		ChainType::Local,
+		move || {
+			testnet_genesis(
+				wasm_binary,
+				// Initial PoA authorities
+				// Pre-funded accounts
+				vec![
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie"),
+					get_account_id_from_seed::<sr25519::Public>("Dave"),
+					get_account_id_from_seed::<sr25519::Public>("Eve"),
+					get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+				],
+				vec![
+					authority_keys_from_seed("Alice"),
+					authority_keys_from_seed("Bob"),
+				],
+				vec![
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+				],
+				20180427,
+			)
+		},
+		// Bootnodes
+		vec![],
+		// Telemetry
+		None,
+		// Protocol ID
+		None,
+		None,
+		// Properties
+		None,
+		// Extensions
+		None,
+	)
 }
 
 pub fn alphanet_config() -> Result<ChainSpec, String> {
-    let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
-    let pubkey_sr = get_key_sr("5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs");
-    let main_account = AccountPublic::from(pubkey_sr).into_account();
+	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+	let pubkey_sr = get_key_sr("5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs");
+	let main_account = AccountPublic::from(pubkey_sr).into_account();
 
-    Ok(ChainSpec::from_genesis(
-        // Name
-        "Alphanet",
-        // ID
-        "alphanet",
-        ChainType::Live,
-        move || {
-            testnet_genesis(
-                wasm_binary,
-                // Initial PoA authorities
-                // Pre-funded accounts
-                vec![main_account.clone()],
-                vec![
-                    get_authority_from_pubkeys(
-                        "5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs",
-                        "5FviP577ihFCP4n8jCnrd38dQDCn2VeM5DAoYNEHbPy7JtWz",
-                    ),
-                    get_authority_from_pubkeys(
-                        "5G1wTFx3iLZCWejfaSGfxQtdKHRzDJ4ga7iabWVS1a9DND2L",
-                        "5FqDv66PJL7TtC49CitcfGNokKJjbL3nwDRmYnQ66BJttUrw",
-                    ),
-                    get_authority_from_pubkeys(
-                        "5Dnet7dgiMJBuAyizMH5EW9JYSXttNKFveQH5Miekrwb4GxJ",
-                        "5GUVATr2DwH51tnqaUEuBtuHA4bLnoWBAkauDxDafMukpZAZ",
-                    ),
-                    get_authority_from_pubkeys(
-                        "5H639iD2JYtZbQN5sNNVRhVtpvzHyhXp5MwGBgW1FLz71zkp",
-                        "5FiEnbnj7VV5CWAtbJXtZjCkiQTBBRqyb8MgXEkydW1SfLiJ",
-                    ),
-                    get_authority_from_pubkeys(
-                        "5DtBoSGDHwH4aLJUA2LVYwprziGEyDopXc4YvdU8LRB1rzdv",
-                        "5GzRrcmG4kztd31FPWEcr51B3Jd2GZPh6ZjpxwzymopHuViN",
-                    ),
-                ],
-                vec![
-                    AccountId::from_string("5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs")
-                        .expect("Bad account id format"),
-                ],
-                20180427,
-            )
-        },
-        // Bootnodes
-        vec![],
-        // Telemetry
-        None,
-        // Protocol ID
-        None,
-        None,
-        // Properties
-        None,
-        // Extensions
-        None,
-    ))
+	Ok(ChainSpec::from_genesis(
+		// Name
+		"Alphanet",
+		// ID
+		"alphanet",
+		ChainType::Live,
+		move || {
+			testnet_genesis(
+				wasm_binary,
+				// Initial PoA authorities
+				// Pre-funded accounts
+				vec![main_account.clone()],
+				vec![
+					get_authority_from_pubkeys(
+						"5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs",
+						"5FviP577ihFCP4n8jCnrd38dQDCn2VeM5DAoYNEHbPy7JtWz",
+					),
+					get_authority_from_pubkeys(
+						"5G1wTFx3iLZCWejfaSGfxQtdKHRzDJ4ga7iabWVS1a9DND2L",
+						"5FqDv66PJL7TtC49CitcfGNokKJjbL3nwDRmYnQ66BJttUrw",
+					),
+					get_authority_from_pubkeys(
+						"5Dnet7dgiMJBuAyizMH5EW9JYSXttNKFveQH5Miekrwb4GxJ",
+						"5GUVATr2DwH51tnqaUEuBtuHA4bLnoWBAkauDxDafMukpZAZ",
+					),
+					get_authority_from_pubkeys(
+						"5H639iD2JYtZbQN5sNNVRhVtpvzHyhXp5MwGBgW1FLz71zkp",
+						"5FiEnbnj7VV5CWAtbJXtZjCkiQTBBRqyb8MgXEkydW1SfLiJ",
+					),
+					get_authority_from_pubkeys(
+						"5DtBoSGDHwH4aLJUA2LVYwprziGEyDopXc4YvdU8LRB1rzdv",
+						"5GzRrcmG4kztd31FPWEcr51B3Jd2GZPh6ZjpxwzymopHuViN",
+					),
+				],
+				vec![
+					AccountId::from_string("5FC9q4Nu51s48cJ9RqTj78zyFhpi2wpC1jzt3hXLAiqkfAbs")
+						.expect("Bad account id format"),
+				],
+				20180427,
+			)
+		},
+		// Bootnodes
+		vec![],
+		// Telemetry
+		None,
+		// Protocol ID
+		None,
+		None,
+		// Properties
+		None,
+		// Extensions
+		None,
+	))
 }
 
 /// Configure initial storage state for FRAME modules.
 fn testnet_genesis(
-    wasm_binary: &[u8],
-    endowed_accounts: Vec<AccountId>,
-    initial_authorities: Vec<(AuraId, GrandpaId)>,
-    members: Vec<AccountId>,
-    chain_id: u64,
+	wasm_binary: &[u8],
+	endowed_accounts: Vec<AccountId>,
+	initial_authorities: Vec<(AuraId, GrandpaId)>,
+	members: Vec<AccountId>,
+	chain_id: u64,
 ) -> GenesisConfig {
-    use stabilty_runtime::{
-        AuraConfig, BalancesConfig, EVMChainIdConfig, EVMConfig, GrandpaConfig, SystemConfig,
-        TechCommitteeCollectiveConfig,
-    };
+	use stabilty_runtime::{
+		AuraConfig, BalancesConfig, EVMChainIdConfig, EVMConfig, GrandpaConfig, SystemConfig,
+		TechCommitteeCollectiveConfig,
+	};
 
-    GenesisConfig {
-        // System
-        system: SystemConfig {
-            // Add Wasm runtime to storage.
-            code: wasm_binary.to_vec(),
-        },
+	GenesisConfig {
+		// System
+		system: SystemConfig {
+			// Add Wasm runtime to storage.
+			code: wasm_binary.to_vec(),
+		},
 
-        // Monetary
-        balances: BalancesConfig {
-            // Configure endowed accounts with initial balance of 1 << 60.
-            balances: endowed_accounts
-                .iter()
-                .cloned()
-                .map(|k| (k, 1 << 60))
-                .collect(),
-        },
-        transaction_payment: Default::default(),
+		// Monetary
+		balances: BalancesConfig {
+			// Configure endowed accounts with initial balance of 1 << 60.
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, 1 << 60))
+				.collect(),
+		},
+		transaction_payment: Default::default(),
 
-        // Consensus
-        aura: AuraConfig {
-            authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-        },
-        grandpa: GrandpaConfig {
-            authorities: initial_authorities
-                .iter()
-                .map(|x| (x.1.clone(), 1))
-                .collect(),
-        },
-        tech_committee_collective: TechCommitteeCollectiveConfig {
-            phantom: Default::default(),
-            members: members.clone(),
-        },
-        // EVM compatibility
-        evm_chain_id: EVMChainIdConfig { chain_id },
-        evm: EVMConfig {
-            accounts: {
-                let mut map = BTreeMap::new();
-                map.insert(
-                    // H160 address of Alice dev account
-                    // Derived from SS58 (42 prefix) address
-                    // SS58: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-                    // hex: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-                    // Using the full hex key, truncating to the first 20 bytes (the first 40 hex chars)
-                    H160::from_str("d43593c715fdd31c61141abd04a99fd6822c8558")
-                        .expect("internal H160 is valid; qed"),
-                    fp_evm::GenesisAccount {
-                        balance: U256::from(1_000_000_000_000_000_000_000_000u128),
-                        code: Default::default(),
-                        nonce: Default::default(),
-                        storage: Default::default(),
-                    },
-                );
-                // Stability testing account
-                map.insert(
-                    H160::from_str("a58482131a8d67725e996af72D91A849AcC0F4A1")
-                        .expect("internal H160 is valid; qed"),
-                    fp_evm::GenesisAccount {
-                        nonce: Default::default(),
-                        balance: U256::from(1_000_000_000_000_000_000_000_000u128),
-                        storage: Default::default(),
-                        code: Default::default(),
-                    },
-                );
-                map.insert(
-                    // H160 address of CI test runner account
-                    H160::from_str("6be02d1d3665660d22ff9624b7be0551ee1ac91b")
-                        .expect("internal H160 is valid; qed"),
-                    fp_evm::GenesisAccount {
-                        balance: U256::from_str("0xffffffffffffffffffffffffffffffff")
-                            .expect("internal U256 is valid; qed"),
-                        code: Default::default(),
-                        nonce: Default::default(),
-                        storage: Default::default(),
-                    },
-                );
-                map.insert(
-                    // H160 address for benchmark usage
-                    H160::from_str("1000000000000000000000000000000000000001")
-                        .expect("internal H160 is valid; qed"),
-                    fp_evm::GenesisAccount {
-                        nonce: U256::from(1),
-                        balance: U256::from(1_000_000_000_000_000_000_000_000u128),
-                        storage: Default::default(),
-                        code: vec![0x00],
-                    },
-                );
-                map
-            },
-        },
-        ethereum: Default::default(),
-        dynamic_fee: Default::default(),
-        base_fee: Default::default(),
-    }
+		// Consensus
+		aura: AuraConfig {
+			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
+		},
+		grandpa: GrandpaConfig {
+			authorities: initial_authorities
+				.iter()
+				.map(|x| (x.1.clone(), 1))
+				.collect(),
+		},
+		tech_committee_collective: TechCommitteeCollectiveConfig {
+			phantom: Default::default(),
+			members: members.clone(),
+		},
+		// EVM compatibility
+		evm_chain_id: EVMChainIdConfig { chain_id },
+		evm: EVMConfig {
+			accounts: {
+				let mut map = BTreeMap::new();
+				map.insert(
+					// H160 address of Alice dev account
+					// Derived from SS58 (42 prefix) address
+					// SS58: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+					// hex: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+					// Using the full hex key, truncating to the first 20 bytes (the first 40 hex chars)
+					H160::from_str("d43593c715fdd31c61141abd04a99fd6822c8558")
+						.expect("internal H160 is valid; qed"),
+					fp_evm::GenesisAccount {
+						balance: U256::from(1_000_000_000_000_000_000_000_000u128),
+						code: Default::default(),
+						nonce: Default::default(),
+						storage: Default::default(),
+					},
+				);
+				// Stability testing account
+				map.insert(
+					H160::from_str("a58482131a8d67725e996af72D91A849AcC0F4A1")
+						.expect("internal H160 is valid; qed"),
+					fp_evm::GenesisAccount {
+						nonce: Default::default(),
+						balance: U256::from(1_000_000_000_000_000_000_000_000u128),
+						storage: Default::default(),
+						code: Default::default(),
+					},
+				);
+				map.insert(
+					// H160 address of CI test runner account
+					H160::from_str("6be02d1d3665660d22ff9624b7be0551ee1ac91b")
+						.expect("internal H160 is valid; qed"),
+					fp_evm::GenesisAccount {
+						balance: U256::from_str("0xffffffffffffffffffffffffffffffff")
+							.expect("internal U256 is valid; qed"),
+						code: Default::default(),
+						nonce: Default::default(),
+						storage: Default::default(),
+					},
+				);
+				map.insert(
+					// H160 address for benchmark usage
+					H160::from_str("1000000000000000000000000000000000000001")
+						.expect("internal H160 is valid; qed"),
+					fp_evm::GenesisAccount {
+						nonce: U256::from(1),
+						balance: U256::from(1_000_000_000_000_000_000_000_000u128),
+						storage: Default::default(),
+						code: vec![0x00],
+					},
+				);
+				map
+			},
+		},
+		ethereum: Default::default(),
+		dynamic_fee: Default::default(),
+		base_fee: Default::default(),
+	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -9,7 +9,9 @@ use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_state_machine::BasicExternalities;
 // Frontier
-use stabilty_runtime::{AccountId, EnableManualSeal, GenesisConfig, Signature, WASM_BINARY};
+use stabilty_runtime::{
+	AccountId, EnableManualSeal, GenesisConfig, Precompiles, Signature, WASM_BINARY,
+};
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -331,6 +333,20 @@ fn testnet_genesis(
 						code: vec![0x00],
 					},
 				);
+				let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
+				Precompiles::used_addresses()
+					.into_iter()
+					.for_each(|addr: H160| {
+						map.insert(
+							addr,
+							fp_evm::GenesisAccount {
+								nonce: Default::default(),
+								balance: Default::default(),
+								storage: Default::default(),
+								code: revert_bytecode.clone(),
+							},
+						);
+					});
 				map
 			},
 		},

--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -11,7 +11,7 @@ use crate::eth::EthCompatRuntimeApiCollection;
 pub type FullBackend = sc_service::TFullBackend<Block>;
 /// Full client.
 pub type FullClient<RuntimeApi, Executor> =
-    sc_service::TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>;
+	sc_service::TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>;
 
 pub type Client = FullClient<stabilty_runtime::RuntimeApi, TemplateRuntimeExecutor>;
 
@@ -24,63 +24,63 @@ pub type HostFunctions = ();
 
 pub struct TemplateRuntimeExecutor;
 impl NativeExecutionDispatch for TemplateRuntimeExecutor {
-    type ExtendHostFunctions = HostFunctions;
+	type ExtendHostFunctions = HostFunctions;
 
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        stabilty_runtime::api::dispatch(method, data)
-    }
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		stabilty_runtime::api::dispatch(method, data)
+	}
 
-    fn native_version() -> NativeVersion {
-        stabilty_runtime::native_version()
-    }
+	fn native_version() -> NativeVersion {
+		stabilty_runtime::native_version()
+	}
 }
 
 /// A set of APIs that every runtimes must implement.
 pub trait BaseRuntimeApiCollection:
-    sp_api::ApiExt<Block>
-    + sp_api::Metadata<Block>
-    + sp_block_builder::BlockBuilder<Block>
-    + sp_offchain::OffchainWorkerApi<Block>
-    + sp_session::SessionKeys<Block>
-    + sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
+	sp_api::ApiExt<Block>
+	+ sp_api::Metadata<Block>
+	+ sp_block_builder::BlockBuilder<Block>
+	+ sp_offchain::OffchainWorkerApi<Block>
+	+ sp_session::SessionKeys<Block>
+	+ sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 where
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }
 
 impl<Api> BaseRuntimeApiCollection for Api
 where
-    Api: sp_api::ApiExt<Block>
-        + sp_api::Metadata<Block>
-        + sp_block_builder::BlockBuilder<Block>
-        + sp_offchain::OffchainWorkerApi<Block>
-        + sp_session::SessionKeys<Block>
-        + sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>,
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	Api: sp_api::ApiExt<Block>
+		+ sp_api::Metadata<Block>
+		+ sp_block_builder::BlockBuilder<Block>
+		+ sp_offchain::OffchainWorkerApi<Block>
+		+ sp_session::SessionKeys<Block>
+		+ sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }
 
 /// A set of APIs that template runtime must implement.
 pub trait RuntimeApiCollection:
-    BaseRuntimeApiCollection
-    + EthCompatRuntimeApiCollection
-    + sp_consensus_aura::AuraApi<Block, AuraId>
-    + sp_finality_grandpa::GrandpaApi<Block>
-    + frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index>
-    + pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance>
+	BaseRuntimeApiCollection
+	+ EthCompatRuntimeApiCollection
+	+ sp_consensus_aura::AuraApi<Block, AuraId>
+	+ sp_finality_grandpa::GrandpaApi<Block>
+	+ frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index>
+	+ pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance>
 where
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }
 
 impl<Api> RuntimeApiCollection for Api
 where
-    Api: BaseRuntimeApiCollection
-        + EthCompatRuntimeApiCollection
-        + sp_consensus_aura::AuraApi<Block, AuraId>
-        + sp_finality_grandpa::GrandpaApi<Block>
-        + frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index>
-        + pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance>,
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	Api: BaseRuntimeApiCollection
+		+ EthCompatRuntimeApiCollection
+		+ sp_consensus_aura::AuraApi<Block, AuraId>
+		+ sp_finality_grandpa::GrandpaApi<Block>
+		+ frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index>
+		+ pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -23,201 +23,201 @@ use sc_service::DatabaseSource;
 use fc_db::frontier_database_dir;
 
 use crate::{
-    chain_spec,
-    cli::{Cli, Subcommand},
-    service::{self, db_config_dir},
+	chain_spec,
+	cli::{Cli, Subcommand},
+	service::{self, db_config_dir},
 };
 
 impl SubstrateCli for Cli {
-    fn impl_name() -> String {
-        "Frontier Node".into()
-    }
+	fn impl_name() -> String {
+		"Frontier Node".into()
+	}
 
-    fn impl_version() -> String {
-        env!("SUBSTRATE_CLI_IMPL_VERSION").into()
-    }
+	fn impl_version() -> String {
+		env!("SUBSTRATE_CLI_IMPL_VERSION").into()
+	}
 
-    fn description() -> String {
-        env!("CARGO_PKG_DESCRIPTION").into()
-    }
+	fn description() -> String {
+		env!("CARGO_PKG_DESCRIPTION").into()
+	}
 
-    fn author() -> String {
-        env!("CARGO_PKG_AUTHORS").into()
-    }
+	fn author() -> String {
+		env!("CARGO_PKG_AUTHORS").into()
+	}
 
-    fn support_url() -> String {
-        "support.anonymous.an".into()
-    }
+	fn support_url() -> String {
+		"support.anonymous.an".into()
+	}
 
-    fn copyright_start_year() -> i32 {
-        2021
-    }
+	fn copyright_start_year() -> i32 {
+		2021
+	}
 
-    fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
-        Ok(match id {
-            "dev" => {
-                let enable_manual_seal = self.sealing.map(|_| true);
-                Box::new(chain_spec::development_config(enable_manual_seal))
-            }
-            "alphanet" => Box::new(chain_spec::alphanet_config()?),
-            "" | "local" => Box::new(chain_spec::local_testnet_config()),
-            path => Box::new(chain_spec::ChainSpec::from_json_file(
-                std::path::PathBuf::from(path),
-            )?),
-        })
-    }
+	fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
+		Ok(match id {
+			"dev" => {
+				let enable_manual_seal = self.sealing.map(|_| true);
+				Box::new(chain_spec::development_config(enable_manual_seal))
+			}
+			"alphanet" => Box::new(chain_spec::alphanet_config()?),
+			"" | "local" => Box::new(chain_spec::local_testnet_config()),
+			path => Box::new(chain_spec::ChainSpec::from_json_file(
+				std::path::PathBuf::from(path),
+			)?),
+		})
+	}
 
-    fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-        &stabilty_runtime::VERSION
-    }
+	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
+		&stabilty_runtime::VERSION
+	}
 }
 
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
-    let cli = Cli::parse();
+	let cli = Cli::parse();
 
-    match &cli.subcommand {
-        Some(Subcommand::Key(cmd)) => cmd.run(&cli),
-        Some(Subcommand::BuildSpec(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-        }
-        Some(Subcommand::CheckBlock(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|mut config| {
-                let (client, _, import_queue, task_manager, _) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                Ok((cmd.run(client, import_queue), task_manager))
-            })
-        }
-        Some(Subcommand::ExportBlocks(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|mut config| {
-                let (client, _, _, task_manager, _) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                Ok((cmd.run(client, config.database), task_manager))
-            })
-        }
-        Some(Subcommand::ExportState(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|mut config| {
-                let (client, _, _, task_manager, _) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                Ok((cmd.run(client, config.chain_spec), task_manager))
-            })
-        }
-        Some(Subcommand::ImportBlocks(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|mut config| {
-                let (client, _, import_queue, task_manager, _) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                Ok((cmd.run(client, import_queue), task_manager))
-            })
-        }
-        Some(Subcommand::PurgeChain(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|config| {
-                // Remove Frontier offchain db
-                let db_config_dir = db_config_dir(&config);
-                let frontier_database_config = match config.database {
-                    DatabaseSource::RocksDb { .. } => DatabaseSource::RocksDb {
-                        path: frontier_database_dir(&db_config_dir, "db"),
-                        cache_size: 0,
-                    },
-                    DatabaseSource::ParityDb { .. } => DatabaseSource::ParityDb {
-                        path: frontier_database_dir(&db_config_dir, "paritydb"),
-                    },
-                    _ => {
-                        return Err(format!("Cannot purge `{:?}` database", config.database).into())
-                    }
-                };
-                cmd.run(frontier_database_config)?;
-                cmd.run(config.database)
-            })
-        }
-        Some(Subcommand::Revert(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.async_run(|mut config| {
-                let (client, backend, _, task_manager, _) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                let aux_revert = Box::new(move |client, _, blocks| {
-                    sc_finality_grandpa::revert(client, blocks)?;
-                    Ok(())
-                });
-                Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
-            })
-        }
-        #[cfg(feature = "runtime-benchmarks")]
-        Some(Subcommand::Benchmark(cmd)) => {
-            use crate::benchmarking::{
-                inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder,
-            };
-            use frame_benchmarking_cli::{
-                BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE,
-            };
-            use stabilty_runtime::{Block, ExistentialDeposit};
+	match &cli.subcommand {
+		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+		Some(Subcommand::BuildSpec(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
+		}
+		Some(Subcommand::CheckBlock(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, _, import_queue, task_manager, _) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				Ok((cmd.run(client, import_queue), task_manager))
+			})
+		}
+		Some(Subcommand::ExportBlocks(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, _, _, task_manager, _) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				Ok((cmd.run(client, config.database), task_manager))
+			})
+		}
+		Some(Subcommand::ExportState(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, _, _, task_manager, _) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				Ok((cmd.run(client, config.chain_spec), task_manager))
+			})
+		}
+		Some(Subcommand::ImportBlocks(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, _, import_queue, task_manager, _) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				Ok((cmd.run(client, import_queue), task_manager))
+			})
+		}
+		Some(Subcommand::PurgeChain(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| {
+				// Remove Frontier offchain db
+				let db_config_dir = db_config_dir(&config);
+				let frontier_database_config = match config.database {
+					DatabaseSource::RocksDb { .. } => DatabaseSource::RocksDb {
+						path: frontier_database_dir(&db_config_dir, "db"),
+						cache_size: 0,
+					},
+					DatabaseSource::ParityDb { .. } => DatabaseSource::ParityDb {
+						path: frontier_database_dir(&db_config_dir, "paritydb"),
+					},
+					_ => {
+						return Err(format!("Cannot purge `{:?}` database", config.database).into())
+					}
+				};
+				cmd.run(frontier_database_config)?;
+				cmd.run(config.database)
+			})
+		}
+		Some(Subcommand::Revert(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, backend, _, task_manager, _) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				let aux_revert = Box::new(move |client, _, blocks| {
+					sc_finality_grandpa::revert(client, blocks)?;
+					Ok(())
+				});
+				Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
+			})
+		}
+		#[cfg(feature = "runtime-benchmarks")]
+		Some(Subcommand::Benchmark(cmd)) => {
+			use crate::benchmarking::{
+				inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder,
+			};
+			use frame_benchmarking_cli::{
+				BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE,
+			};
+			use stabilty_runtime::{Block, ExistentialDeposit};
 
-            let runner = cli.create_runner(cmd)?;
-            match cmd {
-                BenchmarkCmd::Pallet(cmd) => runner
-                    .sync_run(|config| cmd.run::<Block, service::TemplateRuntimeExecutor>(config)),
-                BenchmarkCmd::Block(cmd) => runner.sync_run(|mut config| {
-                    let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
-                    cmd.run(client)
-                }),
-                BenchmarkCmd::Storage(cmd) => runner.sync_run(|mut config| {
-                    let (client, backend, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
-                    let db = backend.expose_db();
-                    let storage = backend.expose_storage();
-                    cmd.run(config, client, db, storage)
-                }),
-                BenchmarkCmd::Overhead(cmd) => runner.sync_run(|mut config| {
-                    let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
-                    let ext_builder = RemarkBuilder::new(client.clone());
-                    cmd.run(
-                        config,
-                        client,
-                        inherent_benchmark_data()?,
-                        Vec::new(),
-                        &ext_builder,
-                    )
-                }),
-                BenchmarkCmd::Extrinsic(cmd) => runner.sync_run(|mut config| {
-                    let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
-                    // Register the *Remark* and *TKA* builders.
-                    let ext_factory = ExtrinsicFactory(vec![
-                        Box::new(RemarkBuilder::new(client.clone())),
-                        Box::new(TransferKeepAliveBuilder::new(
-                            client.clone(),
-                            sp_keyring::Sr25519Keyring::Alice.to_account_id(),
-                            ExistentialDeposit::get(),
-                        )),
-                    ]);
+			let runner = cli.create_runner(cmd)?;
+			match cmd {
+				BenchmarkCmd::Pallet(cmd) => runner
+					.sync_run(|config| cmd.run::<Block, service::TemplateRuntimeExecutor>(config)),
+				BenchmarkCmd::Block(cmd) => runner.sync_run(|mut config| {
+					let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
+					cmd.run(client)
+				}),
+				BenchmarkCmd::Storage(cmd) => runner.sync_run(|mut config| {
+					let (client, backend, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
+					let db = backend.expose_db();
+					let storage = backend.expose_storage();
+					cmd.run(config, client, db, storage)
+				}),
+				BenchmarkCmd::Overhead(cmd) => runner.sync_run(|mut config| {
+					let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
+					let ext_builder = RemarkBuilder::new(client.clone());
+					cmd.run(
+						config,
+						client,
+						inherent_benchmark_data()?,
+						Vec::new(),
+						&ext_builder,
+					)
+				}),
+				BenchmarkCmd::Extrinsic(cmd) => runner.sync_run(|mut config| {
+					let (client, _, _, _, _) = service::new_chain_ops(&mut config, &cli.eth)?;
+					// Register the *Remark* and *TKA* builders.
+					let ext_factory = ExtrinsicFactory(vec![
+						Box::new(RemarkBuilder::new(client.clone())),
+						Box::new(TransferKeepAliveBuilder::new(
+							client.clone(),
+							sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+							ExistentialDeposit::get(),
+						)),
+					]);
 
-                    cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
-                }),
-                BenchmarkCmd::Machine(cmd) => {
-                    runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()))
-                }
-            }
-        }
-        #[cfg(not(feature = "runtime-benchmarks"))]
-        Some(Subcommand::Benchmark) => Err("Benchmarking wasn't enabled when building the node. \
+					cmd.run(client, inherent_benchmark_data()?, Vec::new(), &ext_factory)
+				}),
+				BenchmarkCmd::Machine(cmd) => {
+					runner.sync_run(|config| cmd.run(&config, SUBSTRATE_REFERENCE_HARDWARE.clone()))
+				}
+			}
+		}
+		#[cfg(not(feature = "runtime-benchmarks"))]
+		Some(Subcommand::Benchmark) => Err("Benchmarking wasn't enabled when building the node. \
 			You can enable it with `--features runtime-benchmarks`."
-            .into()),
-        Some(Subcommand::FrontierDb(cmd)) => {
-            let runner = cli.create_runner(cmd)?;
-            runner.sync_run(|mut config| {
-                let (client, _, _, _, frontier_backend) =
-                    service::new_chain_ops(&mut config, &cli.eth)?;
-                cmd.run(client, frontier_backend)
-            })
-        }
-        None => {
-            let runner = cli.create_runner(&cli.run)?;
-            runner.run_node_until_exit(|config| async move {
-                service::build_full(config, cli.eth, cli.sealing).map_err(Into::into)
-            })
-        }
-    }
+			.into()),
+		Some(Subcommand::FrontierDb(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|mut config| {
+				let (client, _, _, _, frontier_backend) =
+					service::new_chain_ops(&mut config, &cli.eth)?;
+				cmd.run(client, frontier_backend)
+			})
+		}
+		None => {
+			let runner = cli.create_runner(&cli.run)?;
+			runner.run_node_until_exit(|config| async move {
+				service::build_full(config, cli.eth, cli.sealing).map_err(Into::into)
+			})
+		}
+	}
 }

--- a/node/src/eth.rs
+++ b/node/src/eth.rs
@@ -1,8 +1,8 @@
 use std::{
-    collections::BTreeMap,
-    path::PathBuf,
-    sync::{Arc, Mutex},
-    time::Duration,
+	collections::BTreeMap,
+	path::PathBuf,
+	sync::{Arc, Mutex},
+	time::Duration,
 };
 
 use futures::{future, prelude::*};
@@ -27,135 +27,135 @@ use crate::client::{FullBackend, FullClient};
 pub type FrontierBackend = fc_db::Backend<Block>;
 
 pub fn db_config_dir(config: &Configuration) -> PathBuf {
-    let application = &config.impl_name;
-    config
-        .base_path
-        .as_ref()
-        .map(|base_path| base_path.config_dir(config.chain_spec.id()))
-        .unwrap_or_else(|| {
-            BasePath::from_project("", "", application).config_dir(config.chain_spec.id())
-        })
+	let application = &config.impl_name;
+	config
+		.base_path
+		.as_ref()
+		.map(|base_path| base_path.config_dir(config.chain_spec.id()))
+		.unwrap_or_else(|| {
+			BasePath::from_project("", "", application).config_dir(config.chain_spec.id())
+		})
 }
 
 /// The ethereum-compatibility configuration used to run a node.
 #[derive(Clone, Debug, clap::Parser)]
 pub struct EthConfiguration {
-    /// Maximum number of logs in a query.
-    #[arg(long, default_value = "10000")]
-    pub max_past_logs: u32,
+	/// Maximum number of logs in a query.
+	#[arg(long, default_value = "10000")]
+	pub max_past_logs: u32,
 
-    /// Maximum fee history cache size.
-    #[arg(long, default_value = "2048")]
-    pub fee_history_limit: u64,
+	/// Maximum fee history cache size.
+	#[arg(long, default_value = "2048")]
+	pub fee_history_limit: u64,
 
-    #[arg(long)]
-    pub enable_dev_signer: bool,
+	#[arg(long)]
+	pub enable_dev_signer: bool,
 
-    /// The dynamic-fee pallet target gas price set by block author
-    #[arg(long, default_value = "1")]
-    pub target_gas_price: u64,
+	/// The dynamic-fee pallet target gas price set by block author
+	#[arg(long, default_value = "1")]
+	pub target_gas_price: u64,
 
-    /// Maximum allowed gas limit will be `block.gas_limit * execute_gas_limit_multiplier`
-    /// when using eth_call/eth_estimateGas.
-    #[arg(long, default_value = "10")]
-    pub execute_gas_limit_multiplier: u64,
+	/// Maximum allowed gas limit will be `block.gas_limit * execute_gas_limit_multiplier`
+	/// when using eth_call/eth_estimateGas.
+	#[arg(long, default_value = "10")]
+	pub execute_gas_limit_multiplier: u64,
 
-    /// Size in bytes of the LRU cache for block data.
-    #[arg(long, default_value = "50")]
-    pub eth_log_block_cache: usize,
+	/// Size in bytes of the LRU cache for block data.
+	#[arg(long, default_value = "50")]
+	pub eth_log_block_cache: usize,
 
-    /// Size in bytes of the LRU cache for transactions statuses data.
-    #[arg(long, default_value = "50")]
-    pub eth_statuses_cache: usize,
+	/// Size in bytes of the LRU cache for transactions statuses data.
+	#[arg(long, default_value = "50")]
+	pub eth_statuses_cache: usize,
 }
 
 pub struct FrontierPartialComponents {
-    pub filter_pool: Option<FilterPool>,
-    pub fee_history_cache: FeeHistoryCache,
-    pub fee_history_cache_limit: FeeHistoryCacheLimit,
+	pub filter_pool: Option<FilterPool>,
+	pub fee_history_cache: FeeHistoryCache,
+	pub fee_history_cache_limit: FeeHistoryCacheLimit,
 }
 
 pub fn new_frontier_partial(
-    config: &EthConfiguration,
+	config: &EthConfiguration,
 ) -> Result<FrontierPartialComponents, ServiceError> {
-    Ok(FrontierPartialComponents {
-        filter_pool: Some(Arc::new(Mutex::new(BTreeMap::new()))),
-        fee_history_cache: Arc::new(Mutex::new(BTreeMap::new())),
-        fee_history_cache_limit: config.fee_history_limit,
-    })
+	Ok(FrontierPartialComponents {
+		filter_pool: Some(Arc::new(Mutex::new(BTreeMap::new()))),
+		fee_history_cache: Arc::new(Mutex::new(BTreeMap::new())),
+		fee_history_cache_limit: config.fee_history_limit,
+	})
 }
 
 /// A set of APIs that ethereum-compatible runtimes must implement.
 pub trait EthCompatRuntimeApiCollection:
-    sp_api::ApiExt<Block>
-    + fp_rpc::EthereumRuntimeRPCApi<Block>
-    + fp_rpc::ConvertTransactionRuntimeApi<Block>
+	sp_api::ApiExt<Block>
+	+ fp_rpc::EthereumRuntimeRPCApi<Block>
+	+ fp_rpc::ConvertTransactionRuntimeApi<Block>
 where
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }
 
 impl<Api> EthCompatRuntimeApiCollection for Api
 where
-    Api: sp_api::ApiExt<Block>
-        + fp_rpc::EthereumRuntimeRPCApi<Block>
-        + fp_rpc::ConvertTransactionRuntimeApi<Block>,
-    <Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+	Api: sp_api::ApiExt<Block>
+		+ fp_rpc::EthereumRuntimeRPCApi<Block>
+		+ fp_rpc::ConvertTransactionRuntimeApi<Block>,
+	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {
 }
 
 pub fn spawn_frontier_tasks<RuntimeApi, Executor>(
-    task_manager: &TaskManager,
-    client: Arc<FullClient<RuntimeApi, Executor>>,
-    backend: Arc<FullBackend>,
-    frontier_backend: Arc<FrontierBackend>,
-    filter_pool: Option<FilterPool>,
-    overrides: Arc<OverrideHandle<Block>>,
-    fee_history_cache: FeeHistoryCache,
-    fee_history_cache_limit: FeeHistoryCacheLimit,
+	task_manager: &TaskManager,
+	client: Arc<FullClient<RuntimeApi, Executor>>,
+	backend: Arc<FullBackend>,
+	frontier_backend: Arc<FrontierBackend>,
+	filter_pool: Option<FilterPool>,
+	overrides: Arc<OverrideHandle<Block>>,
+	fee_history_cache: FeeHistoryCache,
+	fee_history_cache_limit: FeeHistoryCacheLimit,
 ) where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        EthCompatRuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		EthCompatRuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
 {
-    task_manager.spawn_essential_handle().spawn(
-        "frontier-mapping-sync-worker",
-        Some("frontier"),
-        MappingSyncWorker::new(
-            client.import_notification_stream(),
-            Duration::new(6, 0),
-            client.clone(),
-            backend,
-            frontier_backend,
-            3,
-            0,
-            SyncStrategy::Normal,
-        )
-        .for_each(|()| future::ready(())),
-    );
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-mapping-sync-worker",
+		Some("frontier"),
+		MappingSyncWorker::new(
+			client.import_notification_stream(),
+			Duration::new(6, 0),
+			client.clone(),
+			backend,
+			frontier_backend,
+			3,
+			0,
+			SyncStrategy::Normal,
+		)
+		.for_each(|()| future::ready(())),
+	);
 
-    // Spawn Frontier EthFilterApi maintenance task.
-    if let Some(filter_pool) = filter_pool {
-        // Each filter is allowed to stay in the pool for 100 blocks.
-        const FILTER_RETAIN_THRESHOLD: u64 = 100;
-        task_manager.spawn_essential_handle().spawn(
-            "frontier-filter-pool",
-            Some("frontier"),
-            EthTask::filter_pool_task(client.clone(), filter_pool, FILTER_RETAIN_THRESHOLD),
-        );
-    }
+	// Spawn Frontier EthFilterApi maintenance task.
+	if let Some(filter_pool) = filter_pool {
+		// Each filter is allowed to stay in the pool for 100 blocks.
+		const FILTER_RETAIN_THRESHOLD: u64 = 100;
+		task_manager.spawn_essential_handle().spawn(
+			"frontier-filter-pool",
+			Some("frontier"),
+			EthTask::filter_pool_task(client.clone(), filter_pool, FILTER_RETAIN_THRESHOLD),
+		);
+	}
 
-    // Spawn Frontier FeeHistory cache maintenance task.
-    task_manager.spawn_essential_handle().spawn(
-        "frontier-fee-history",
-        Some("frontier"),
-        EthTask::fee_history_task(
-            client,
-            overrides,
-            fee_history_cache,
-            fee_history_cache_limit,
-        ),
-    );
+	// Spawn Frontier FeeHistory cache maintenance task.
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-fee-history",
+		Some("frontier"),
+		EthTask::fee_history_task(
+			client,
+			overrides,
+			fee_history_cache,
+			fee_history_cache_limit,
+		),
+	);
 }

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -6,8 +6,8 @@ use futures::channel::mpsc;
 use jsonrpsee::RpcModule;
 // Substrate
 use sc_client_api::{
-    backend::{AuxStore, Backend, StateBackend, StorageProvider},
-    client::BlockchainEvents,
+	backend::{AuxStore, Backend, StateBackend, StorageProvider},
+	client::BlockchainEvents,
 };
 use sc_consensus_manual_seal::rpc::EngineCommand;
 use sc_rpc::SubscriptionTaskExecutor;
@@ -26,65 +26,65 @@ pub use self::eth::{create_eth, overrides_handle, EthDeps};
 
 /// Full client dependencies.
 pub struct FullDeps<C, P, A: ChainApi, CT> {
-    /// The client instance to use.
-    pub client: Arc<C>,
-    /// Transaction pool instance.
-    pub pool: Arc<P>,
-    /// Whether to deny unsafe calls
-    pub deny_unsafe: DenyUnsafe,
-    /// Manual seal command sink
-    pub command_sink: Option<mpsc::Sender<EngineCommand<Hash>>>,
-    /// Ethereum-compatibility specific dependencies.
-    pub eth: EthDeps<C, P, A, CT, Block>,
+	/// The client instance to use.
+	pub client: Arc<C>,
+	/// Transaction pool instance.
+	pub pool: Arc<P>,
+	/// Whether to deny unsafe calls
+	pub deny_unsafe: DenyUnsafe,
+	/// Manual seal command sink
+	pub command_sink: Option<mpsc::Sender<EngineCommand<Hash>>>,
+	/// Ethereum-compatibility specific dependencies.
+	pub eth: EthDeps<C, P, A, CT, Block>,
 }
 
 /// Instantiate all Full RPC extensions.
 pub fn create_full<C, P, BE, A, CT>(
-    deps: FullDeps<C, P, A, CT>,
-    subscription_task_executor: SubscriptionTaskExecutor,
+	deps: FullDeps<C, P, A, CT>,
+	subscription_task_executor: SubscriptionTaskExecutor,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
-    BE: Backend<Block> + 'static,
-    BE::State: StateBackend<BlakeTwo256>,
-    C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
-    C: BlockchainEvents<Block>,
-    C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
-    C: Send + Sync + 'static,
-    C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-    C::Api: BlockBuilder<Block>,
-    C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-    C::Api: fp_rpc::ConvertTransactionRuntimeApi<Block>,
-    C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
-    P: TransactionPool<Block = Block> + 'static,
-    A: ChainApi<Block = Block> + 'static,
-    CT: fp_rpc::ConvertTransaction<<Block as BlockT>::Extrinsic> + Send + Sync + 'static,
+	BE: Backend<Block> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
+	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
+	C: BlockchainEvents<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
+	C: Send + Sync + 'static,
+	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: BlockBuilder<Block>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: fp_rpc::ConvertTransactionRuntimeApi<Block>,
+	C::Api: fp_rpc::EthereumRuntimeRPCApi<Block>,
+	P: TransactionPool<Block = Block> + 'static,
+	A: ChainApi<Block = Block> + 'static,
+	CT: fp_rpc::ConvertTransaction<<Block as BlockT>::Extrinsic> + Send + Sync + 'static,
 {
-    use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
-    use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApiServer};
-    use substrate_frame_rpc_system::{System, SystemApiServer};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
+	use sc_consensus_manual_seal::rpc::{ManualSeal, ManualSealApiServer};
+	use substrate_frame_rpc_system::{System, SystemApiServer};
 
-    let mut io = RpcModule::new(());
-    let FullDeps {
-        client,
-        pool,
-        deny_unsafe,
-        command_sink,
-        eth,
-    } = deps;
+	let mut io = RpcModule::new(());
+	let FullDeps {
+		client,
+		pool,
+		deny_unsafe,
+		command_sink,
+		eth,
+	} = deps;
 
-    io.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
-    io.merge(TransactionPayment::new(client).into_rpc())?;
+	io.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
+	io.merge(TransactionPayment::new(client).into_rpc())?;
 
-    if let Some(command_sink) = command_sink {
-        io.merge(
-            // We provide the rpc handler with the sending end of the channel to allow the rpc
-            // send EngineCommands to the background block authorship task.
-            ManualSeal::new(command_sink).into_rpc(),
-        )?;
-    }
+	if let Some(command_sink) = command_sink {
+		io.merge(
+			// We provide the rpc handler with the sending end of the channel to allow the rpc
+			// send EngineCommands to the background block authorship task.
+			ManualSeal::new(command_sink).into_rpc(),
+		)?;
+	}
 
-    // Ethereum compatibility RPCs
-    let io = create_eth::<_, _, _, _, _, _>(io, eth, subscription_task_executor)?;
+	// Ethereum compatibility RPCs
+	let io = create_eth::<_, _, _, _, _, _>(io, eth, subscription_task_executor)?;
 
-    Ok(io)
+	Ok(io)
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -19,16 +19,16 @@ use sp_trie::PrefixedMemoryDB;
 use stabilty_runtime::{opaque::Block, Hash, TransactionConverter};
 
 use crate::{
-    cli::Sealing,
-    client::{BaseRuntimeApiCollection, FullBackend, FullClient, RuntimeApiCollection},
-    eth::{
-        new_frontier_partial, spawn_frontier_tasks, FrontierBackend, FrontierBlockImport,
-        FrontierPartialComponents,
-    },
+	cli::Sealing,
+	client::{BaseRuntimeApiCollection, FullBackend, FullClient, RuntimeApiCollection},
+	eth::{
+		new_frontier_partial, spawn_frontier_tasks, FrontierBackend, FrontierBlockImport,
+		FrontierPartialComponents,
+	},
 };
 pub use crate::{
-    client::{Client, TemplateRuntimeExecutor},
-    eth::{db_config_dir, EthConfiguration},
+	client::{Client, TemplateRuntimeExecutor},
+	eth::{db_config_dir, EthConfiguration},
 };
 
 type BasicImportQueue<Client> = sc_consensus::DefaultImportQueue<Block, Client>;
@@ -36,628 +36,628 @@ type FullPool<Client> = sc_transaction_pool::FullPool<Block, Client>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 type GrandpaBlockImport<Client> =
-    sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, Client, FullSelectChain>;
+	sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, Client, FullSelectChain>;
 type GrandpaLinkHalf<Client> = sc_finality_grandpa::LinkHalf<Block, Client, FullSelectChain>;
 type BoxBlockImport<Client> = sc_consensus::BoxBlockImport<Block, TransactionFor<Client, Block>>;
 
 pub fn new_partial<RuntimeApi, Executor, BIQ>(
-    config: &Configuration,
-    eth_config: &EthConfiguration,
-    build_import_queue: BIQ,
+	config: &Configuration,
+	eth_config: &EthConfiguration,
+	build_import_queue: BIQ,
 ) -> Result<
-    PartialComponents<
-        FullClient<RuntimeApi, Executor>,
-        FullBackend,
-        FullSelectChain,
-        BasicImportQueue<FullClient<RuntimeApi, Executor>>,
-        FullPool<FullClient<RuntimeApi, Executor>>,
-        (
-            Option<Telemetry>,
-            BoxBlockImport<FullClient<RuntimeApi, Executor>>,
-            GrandpaLinkHalf<FullClient<RuntimeApi, Executor>>,
-            Arc<FrontierBackend>,
-        ),
-    >,
-    ServiceError,
+	PartialComponents<
+		FullClient<RuntimeApi, Executor>,
+		FullBackend,
+		FullSelectChain,
+		BasicImportQueue<FullClient<RuntimeApi, Executor>>,
+		FullPool<FullClient<RuntimeApi, Executor>>,
+		(
+			Option<Telemetry>,
+			BoxBlockImport<FullClient<RuntimeApi, Executor>>,
+			GrandpaLinkHalf<FullClient<RuntimeApi, Executor>>,
+			Arc<FrontierBackend>,
+		),
+	>,
+	ServiceError,
 >
 where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        BaseRuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
-    BIQ: FnOnce(
-        Arc<FullClient<RuntimeApi, Executor>>,
-        &Configuration,
-        &EthConfiguration,
-        &TaskManager,
-        Option<TelemetryHandle>,
-        GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
-        Arc<FrontierBackend>,
-    ) -> Result<
-        (
-            BasicImportQueue<FullClient<RuntimeApi, Executor>>,
-            BoxBlockImport<FullClient<RuntimeApi, Executor>>,
-        ),
-        ServiceError,
-    >,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		BaseRuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
+	BIQ: FnOnce(
+		Arc<FullClient<RuntimeApi, Executor>>,
+		&Configuration,
+		&EthConfiguration,
+		&TaskManager,
+		Option<TelemetryHandle>,
+		GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
+		Arc<FrontierBackend>,
+	) -> Result<
+		(
+			BasicImportQueue<FullClient<RuntimeApi, Executor>>,
+			BoxBlockImport<FullClient<RuntimeApi, Executor>>,
+		),
+		ServiceError,
+	>,
 {
-    let telemetry = config
-        .telemetry_endpoints
-        .clone()
-        .filter(|x| !x.is_empty())
-        .map(|endpoints| -> Result<_, sc_telemetry::Error> {
-            let worker = TelemetryWorker::new(16)?;
-            let telemetry = worker.handle().new_telemetry(endpoints);
-            Ok((worker, telemetry))
-        })
-        .transpose()?;
+	let telemetry = config
+		.telemetry_endpoints
+		.clone()
+		.filter(|x| !x.is_empty())
+		.map(|endpoints| -> Result<_, sc_telemetry::Error> {
+			let worker = TelemetryWorker::new(16)?;
+			let telemetry = worker.handle().new_telemetry(endpoints);
+			Ok((worker, telemetry))
+		})
+		.transpose()?;
 
-    let executor = NativeElseWasmExecutor::<Executor>::new(
-        config.wasm_method,
-        config.default_heap_pages,
-        config.max_runtime_instances,
-        config.runtime_cache_size,
-    );
+	let executor = NativeElseWasmExecutor::<Executor>::new(
+		config.wasm_method,
+		config.default_heap_pages,
+		config.max_runtime_instances,
+		config.runtime_cache_size,
+	);
 
-    let (client, backend, keystore_container, task_manager) =
-        sc_service::new_full_parts::<Block, RuntimeApi, _>(
-            config,
-            telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
-            executor,
-        )?;
-    let client = Arc::new(client);
+	let (client, backend, keystore_container, task_manager) =
+		sc_service::new_full_parts::<Block, RuntimeApi, _>(
+			config,
+			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
+			executor,
+		)?;
+	let client = Arc::new(client);
 
-    let telemetry = telemetry.map(|(worker, telemetry)| {
-        task_manager
-            .spawn_handle()
-            .spawn("telemetry", None, worker.run());
-        telemetry
-    });
+	let telemetry = telemetry.map(|(worker, telemetry)| {
+		task_manager
+			.spawn_handle()
+			.spawn("telemetry", None, worker.run());
+		telemetry
+	});
 
-    let select_chain = sc_consensus::LongestChain::new(backend.clone());
-    let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
-        client.clone(),
-        &(client.clone() as Arc<_>),
-        select_chain.clone(),
-        telemetry.as_ref().map(|x| x.handle()),
-    )?;
+	let select_chain = sc_consensus::LongestChain::new(backend.clone());
+	let (grandpa_block_import, grandpa_link) = sc_finality_grandpa::block_import(
+		client.clone(),
+		&(client.clone() as Arc<_>),
+		select_chain.clone(),
+		telemetry.as_ref().map(|x| x.handle()),
+	)?;
 
-    let frontier_backend = Arc::new(FrontierBackend::open(
-        client.clone(),
-        &config.database,
-        &db_config_dir(config),
-    )?);
-    let (import_queue, block_import) = build_import_queue(
-        client.clone(),
-        config,
-        eth_config,
-        &task_manager,
-        telemetry.as_ref().map(|x| x.handle()),
-        grandpa_block_import,
-        frontier_backend.clone(),
-    )?;
+	let frontier_backend = Arc::new(FrontierBackend::open(
+		client.clone(),
+		&config.database,
+		&db_config_dir(config),
+	)?);
+	let (import_queue, block_import) = build_import_queue(
+		client.clone(),
+		config,
+		eth_config,
+		&task_manager,
+		telemetry.as_ref().map(|x| x.handle()),
+		grandpa_block_import,
+		frontier_backend.clone(),
+	)?;
 
-    let transaction_pool = sc_transaction_pool::BasicPool::new_full(
-        config.transaction_pool.clone(),
-        config.role.is_authority().into(),
-        config.prometheus_registry(),
-        task_manager.spawn_essential_handle(),
-        client.clone(),
-    );
+	let transaction_pool = sc_transaction_pool::BasicPool::new_full(
+		config.transaction_pool.clone(),
+		config.role.is_authority().into(),
+		config.prometheus_registry(),
+		task_manager.spawn_essential_handle(),
+		client.clone(),
+	);
 
-    Ok(PartialComponents {
-        client,
-        backend,
-        keystore_container,
-        task_manager,
-        select_chain,
-        import_queue,
-        transaction_pool,
-        other: (telemetry, block_import, grandpa_link, frontier_backend),
-    })
+	Ok(PartialComponents {
+		client,
+		backend,
+		keystore_container,
+		task_manager,
+		select_chain,
+		import_queue,
+		transaction_pool,
+		other: (telemetry, block_import, grandpa_link, frontier_backend),
+	})
 }
 
 /// Build the import queue for the template runtime (aura + grandpa).
 pub fn build_aura_grandpa_import_queue<RuntimeApi, Executor>(
-    client: Arc<FullClient<RuntimeApi, Executor>>,
-    config: &Configuration,
-    eth_config: &EthConfiguration,
-    task_manager: &TaskManager,
-    telemetry: Option<TelemetryHandle>,
-    grandpa_block_import: GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
-    frontier_backend: Arc<FrontierBackend>,
+	client: Arc<FullClient<RuntimeApi, Executor>>,
+	config: &Configuration,
+	eth_config: &EthConfiguration,
+	task_manager: &TaskManager,
+	telemetry: Option<TelemetryHandle>,
+	grandpa_block_import: GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
+	frontier_backend: Arc<FrontierBackend>,
 ) -> Result<
-    (
-        BasicImportQueue<FullClient<RuntimeApi, Executor>>,
-        BoxBlockImport<FullClient<RuntimeApi, Executor>>,
-    ),
-    ServiceError,
+	(
+		BasicImportQueue<FullClient<RuntimeApi, Executor>>,
+		BoxBlockImport<FullClient<RuntimeApi, Executor>>,
+	),
+	ServiceError,
 >
 where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
 {
-    let frontier_block_import = FrontierBlockImport::new(
-        grandpa_block_import.clone(),
-        client.clone(),
-        frontier_backend,
-    );
+	let frontier_block_import = FrontierBlockImport::new(
+		grandpa_block_import.clone(),
+		client.clone(),
+		frontier_backend,
+	);
 
-    let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
-    let target_gas_price = eth_config.target_gas_price;
-    let create_inherent_data_providers = move |_, ()| async move {
-        let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-        let slot =
-            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-                *timestamp,
-                slot_duration,
-            );
-        let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
-        Ok((slot, timestamp, dynamic_fee))
-    };
+	let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+	let target_gas_price = eth_config.target_gas_price;
+	let create_inherent_data_providers = move |_, ()| async move {
+		let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+		let slot =
+			sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+				*timestamp,
+				slot_duration,
+			);
+		let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
+		Ok((slot, timestamp, dynamic_fee))
+	};
 
-    let import_queue = sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(
-        sc_consensus_aura::ImportQueueParams {
-            block_import: frontier_block_import.clone(),
-            justification_import: Some(Box::new(grandpa_block_import)),
-            client,
-            create_inherent_data_providers,
-            spawner: &task_manager.spawn_essential_handle(),
-            registry: config.prometheus_registry(),
-            check_for_equivocation: Default::default(),
-            telemetry,
-            compatibility_mode: sc_consensus_aura::CompatibilityMode::None,
-        },
-    )
-    .map_err::<ServiceError, _>(Into::into)?;
+	let import_queue = sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(
+		sc_consensus_aura::ImportQueueParams {
+			block_import: frontier_block_import.clone(),
+			justification_import: Some(Box::new(grandpa_block_import)),
+			client,
+			create_inherent_data_providers,
+			spawner: &task_manager.spawn_essential_handle(),
+			registry: config.prometheus_registry(),
+			check_for_equivocation: Default::default(),
+			telemetry,
+			compatibility_mode: sc_consensus_aura::CompatibilityMode::None,
+		},
+	)
+	.map_err::<ServiceError, _>(Into::into)?;
 
-    Ok((import_queue, Box::new(frontier_block_import)))
+	Ok((import_queue, Box::new(frontier_block_import)))
 }
 
 /// Build the import queue for the template runtime (manual seal).
 pub fn build_manual_seal_import_queue<RuntimeApi, Executor>(
-    client: Arc<FullClient<RuntimeApi, Executor>>,
-    config: &Configuration,
-    _eth_config: &EthConfiguration,
-    task_manager: &TaskManager,
-    _telemetry: Option<TelemetryHandle>,
-    _grandpa_block_import: GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
-    frontier_backend: Arc<FrontierBackend>,
+	client: Arc<FullClient<RuntimeApi, Executor>>,
+	config: &Configuration,
+	_eth_config: &EthConfiguration,
+	task_manager: &TaskManager,
+	_telemetry: Option<TelemetryHandle>,
+	_grandpa_block_import: GrandpaBlockImport<FullClient<RuntimeApi, Executor>>,
+	frontier_backend: Arc<FrontierBackend>,
 ) -> Result<
-    (
-        BasicImportQueue<FullClient<RuntimeApi, Executor>>,
-        BoxBlockImport<FullClient<RuntimeApi, Executor>>,
-    ),
-    ServiceError,
+	(
+		BasicImportQueue<FullClient<RuntimeApi, Executor>>,
+		BoxBlockImport<FullClient<RuntimeApi, Executor>>,
+	),
+	ServiceError,
 >
 where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
 {
-    let frontier_block_import = FrontierBlockImport::new(client.clone(), client, frontier_backend);
-    Ok((
-        sc_consensus_manual_seal::import_queue(
-            Box::new(frontier_block_import.clone()),
-            &task_manager.spawn_essential_handle(),
-            config.prometheus_registry(),
-        ),
-        Box::new(frontier_block_import),
-    ))
+	let frontier_block_import = FrontierBlockImport::new(client.clone(), client, frontier_backend);
+	Ok((
+		sc_consensus_manual_seal::import_queue(
+			Box::new(frontier_block_import.clone()),
+			&task_manager.spawn_essential_handle(),
+			config.prometheus_registry(),
+		),
+		Box::new(frontier_block_import),
+	))
 }
 
 /// Builds a new service for a full client.
 pub fn new_full<RuntimeApi, Executor>(
-    mut config: Configuration,
-    eth_config: EthConfiguration,
-    sealing: Option<Sealing>,
+	mut config: Configuration,
+	eth_config: EthConfiguration,
+	sealing: Option<Sealing>,
 ) -> Result<TaskManager, ServiceError>
 where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
 {
-    let build_import_queue = if sealing.is_some() {
-        build_manual_seal_import_queue::<RuntimeApi, Executor>
-    } else {
-        build_aura_grandpa_import_queue::<RuntimeApi, Executor>
-    };
+	let build_import_queue = if sealing.is_some() {
+		build_manual_seal_import_queue::<RuntimeApi, Executor>
+	} else {
+		build_aura_grandpa_import_queue::<RuntimeApi, Executor>
+	};
 
-    let PartialComponents {
-        client,
-        backend,
-        mut task_manager,
-        import_queue,
-        keystore_container,
-        select_chain,
-        transaction_pool,
-        other: (mut telemetry, block_import, grandpa_link, frontier_backend),
-    } = new_partial(&config, &eth_config, build_import_queue)?;
+	let PartialComponents {
+		client,
+		backend,
+		mut task_manager,
+		import_queue,
+		keystore_container,
+		select_chain,
+		transaction_pool,
+		other: (mut telemetry, block_import, grandpa_link, frontier_backend),
+	} = new_partial(&config, &eth_config, build_import_queue)?;
 
-    let FrontierPartialComponents {
-        filter_pool,
-        fee_history_cache,
-        fee_history_cache_limit,
-    } = new_frontier_partial(&eth_config)?;
+	let FrontierPartialComponents {
+		filter_pool,
+		fee_history_cache,
+		fee_history_cache_limit,
+	} = new_frontier_partial(&eth_config)?;
 
-    let grandpa_protocol_name = sc_finality_grandpa::protocol_standard_name(
-        &client.block_hash(0)?.expect("Genesis block exists; qed"),
-        &config.chain_spec,
-    );
+	let grandpa_protocol_name = sc_finality_grandpa::protocol_standard_name(
+		&client.block_hash(0)?.expect("Genesis block exists; qed"),
+		&config.chain_spec,
+	);
 
-    let warp_sync: Option<Arc<dyn sc_network::config::WarpSyncProvider<Block>>> =
-        if sealing.is_some() {
-            None
-        } else {
-            config
-                .network
-                .extra_sets
-                .push(sc_finality_grandpa::grandpa_peers_set_config(
-                    grandpa_protocol_name.clone(),
-                ));
-            Some(Arc::new(
-                sc_finality_grandpa::warp_proof::NetworkProvider::new(
-                    backend.clone(),
-                    grandpa_link.shared_authority_set().clone(),
-                    Vec::default(),
-                ),
-            ))
-        };
+	let warp_sync: Option<Arc<dyn sc_network::config::WarpSyncProvider<Block>>> =
+		if sealing.is_some() {
+			None
+		} else {
+			config
+				.network
+				.extra_sets
+				.push(sc_finality_grandpa::grandpa_peers_set_config(
+					grandpa_protocol_name.clone(),
+				));
+			Some(Arc::new(
+				sc_finality_grandpa::warp_proof::NetworkProvider::new(
+					backend.clone(),
+					grandpa_link.shared_authority_set().clone(),
+					Vec::default(),
+				),
+			))
+		};
 
-    let (network, system_rpc_tx, tx_handler_controller, network_starter) =
-        sc_service::build_network(sc_service::BuildNetworkParams {
-            config: &config,
-            client: client.clone(),
-            transaction_pool: transaction_pool.clone(),
-            spawn_handle: task_manager.spawn_handle(),
-            import_queue,
-            block_announce_validator_builder: None,
-            warp_sync,
-        })?;
+	let (network, system_rpc_tx, tx_handler_controller, network_starter) =
+		sc_service::build_network(sc_service::BuildNetworkParams {
+			config: &config,
+			client: client.clone(),
+			transaction_pool: transaction_pool.clone(),
+			spawn_handle: task_manager.spawn_handle(),
+			import_queue,
+			block_announce_validator_builder: None,
+			warp_sync,
+		})?;
 
-    if config.offchain_worker.enabled {
-        sc_service::build_offchain_workers(
-            &config,
-            task_manager.spawn_handle(),
-            client.clone(),
-            network.clone(),
-        );
-    }
+	if config.offchain_worker.enabled {
+		sc_service::build_offchain_workers(
+			&config,
+			task_manager.spawn_handle(),
+			client.clone(),
+			network.clone(),
+		);
+	}
 
-    let role = config.role.clone();
-    let force_authoring = config.force_authoring;
-    let name = config.network.node_name.clone();
-    let enable_grandpa = !config.disable_grandpa && sealing.is_none();
-    let prometheus_registry = config.prometheus_registry().cloned();
+	let role = config.role.clone();
+	let force_authoring = config.force_authoring;
+	let name = config.network.node_name.clone();
+	let enable_grandpa = !config.disable_grandpa && sealing.is_none();
+	let prometheus_registry = config.prometheus_registry().cloned();
 
-    // Channel for the rpc handler to communicate with the authorship task.
-    let (command_sink, commands_stream) = mpsc::channel(1000);
+	// Channel for the rpc handler to communicate with the authorship task.
+	let (command_sink, commands_stream) = mpsc::channel(1000);
 
-    // for ethereum-compatibility rpc.
-    config.rpc_id_provider = Some(Box::new(fc_rpc::EthereumSubIdProvider));
-    let overrides = crate::rpc::overrides_handle(client.clone());
-    let eth_rpc_params = crate::rpc::EthDeps {
-        client: client.clone(),
-        pool: transaction_pool.clone(),
-        graph: transaction_pool.pool().clone(),
-        converter: Some(TransactionConverter),
-        is_authority: config.role.is_authority(),
-        enable_dev_signer: eth_config.enable_dev_signer,
-        network: network.clone(),
-        frontier_backend: frontier_backend.clone(),
-        overrides: overrides.clone(),
-        block_data_cache: Arc::new(fc_rpc::EthBlockDataCacheTask::new(
-            task_manager.spawn_handle(),
-            overrides.clone(),
-            eth_config.eth_log_block_cache,
-            eth_config.eth_statuses_cache,
-            prometheus_registry.clone(),
-        )),
-        filter_pool: filter_pool.clone(),
-        max_past_logs: eth_config.max_past_logs,
-        fee_history_cache: fee_history_cache.clone(),
-        fee_history_cache_limit,
-        execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
-    };
+	// for ethereum-compatibility rpc.
+	config.rpc_id_provider = Some(Box::new(fc_rpc::EthereumSubIdProvider));
+	let overrides = crate::rpc::overrides_handle(client.clone());
+	let eth_rpc_params = crate::rpc::EthDeps {
+		client: client.clone(),
+		pool: transaction_pool.clone(),
+		graph: transaction_pool.pool().clone(),
+		converter: Some(TransactionConverter),
+		is_authority: config.role.is_authority(),
+		enable_dev_signer: eth_config.enable_dev_signer,
+		network: network.clone(),
+		frontier_backend: frontier_backend.clone(),
+		overrides: overrides.clone(),
+		block_data_cache: Arc::new(fc_rpc::EthBlockDataCacheTask::new(
+			task_manager.spawn_handle(),
+			overrides.clone(),
+			eth_config.eth_log_block_cache,
+			eth_config.eth_statuses_cache,
+			prometheus_registry.clone(),
+		)),
+		filter_pool: filter_pool.clone(),
+		max_past_logs: eth_config.max_past_logs,
+		fee_history_cache: fee_history_cache.clone(),
+		fee_history_cache_limit,
+		execute_gas_limit_multiplier: eth_config.execute_gas_limit_multiplier,
+	};
 
-    let rpc_builder = {
-        let client = client.clone();
-        let pool = transaction_pool.clone();
+	let rpc_builder = {
+		let client = client.clone();
+		let pool = transaction_pool.clone();
 
-        Box::new(move |deny_unsafe, subscription_task_executor| {
-            let deps = crate::rpc::FullDeps {
-                client: client.clone(),
-                pool: pool.clone(),
-                deny_unsafe,
-                command_sink: if sealing.is_some() {
-                    Some(command_sink.clone())
-                } else {
-                    None
-                },
-                eth: eth_rpc_params.clone(),
-            };
+		Box::new(move |deny_unsafe, subscription_task_executor| {
+			let deps = crate::rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				deny_unsafe,
+				command_sink: if sealing.is_some() {
+					Some(command_sink.clone())
+				} else {
+					None
+				},
+				eth: eth_rpc_params.clone(),
+			};
 
-            crate::rpc::create_full(deps, subscription_task_executor).map_err(Into::into)
-        })
-    };
+			crate::rpc::create_full(deps, subscription_task_executor).map_err(Into::into)
+		})
+	};
 
-    let _rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
-        config,
-        client: client.clone(),
-        backend: backend.clone(),
-        task_manager: &mut task_manager,
-        keystore: keystore_container.sync_keystore(),
-        transaction_pool: transaction_pool.clone(),
-        rpc_builder,
-        network: network.clone(),
-        system_rpc_tx,
-        tx_handler_controller,
-        telemetry: telemetry.as_mut(),
-    })?;
+	let _rpc_handlers = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+		config,
+		client: client.clone(),
+		backend: backend.clone(),
+		task_manager: &mut task_manager,
+		keystore: keystore_container.sync_keystore(),
+		transaction_pool: transaction_pool.clone(),
+		rpc_builder,
+		network: network.clone(),
+		system_rpc_tx,
+		tx_handler_controller,
+		telemetry: telemetry.as_mut(),
+	})?;
 
-    spawn_frontier_tasks(
-        &task_manager,
-        client.clone(),
-        backend,
-        frontier_backend,
-        filter_pool,
-        overrides,
-        fee_history_cache,
-        fee_history_cache_limit,
-    );
+	spawn_frontier_tasks(
+		&task_manager,
+		client.clone(),
+		backend,
+		frontier_backend,
+		filter_pool,
+		overrides,
+		fee_history_cache,
+		fee_history_cache_limit,
+	);
 
-    if role.is_authority() {
-        // manual-seal authorship
-        if let Some(sealing) = sealing {
-            run_manual_seal_authorship(
-                &eth_config,
-                sealing,
-                client,
-                transaction_pool,
-                select_chain,
-                block_import,
-                &task_manager,
-                prometheus_registry.as_ref(),
-                telemetry.as_ref(),
-                commands_stream,
-            )?;
+	if role.is_authority() {
+		// manual-seal authorship
+		if let Some(sealing) = sealing {
+			run_manual_seal_authorship(
+				&eth_config,
+				sealing,
+				client,
+				transaction_pool,
+				select_chain,
+				block_import,
+				&task_manager,
+				prometheus_registry.as_ref(),
+				telemetry.as_ref(),
+				commands_stream,
+			)?;
 
-            network_starter.start_network();
-            log::info!("Manual Seal Ready");
-            return Ok(task_manager);
-        }
+			network_starter.start_network();
+			log::info!("Manual Seal Ready");
+			return Ok(task_manager);
+		}
 
-        let proposer_factory = sc_basic_authorship::ProposerFactory::new(
-            task_manager.spawn_handle(),
-            client.clone(),
-            transaction_pool,
-            prometheus_registry.as_ref(),
-            telemetry.as_ref().map(|x| x.handle()),
-        );
+		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+			task_manager.spawn_handle(),
+			client.clone(),
+			transaction_pool,
+			prometheus_registry.as_ref(),
+			telemetry.as_ref().map(|x| x.handle()),
+		);
 
-        let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
-        let target_gas_price = eth_config.target_gas_price;
-        let create_inherent_data_providers = move |_, ()| async move {
-            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-            let slot = sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+		let target_gas_price = eth_config.target_gas_price;
+		let create_inherent_data_providers = move |_, ()| async move {
+			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+			let slot = sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
 				*timestamp,
 				slot_duration,
 			);
-            let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
-            Ok((slot, timestamp, dynamic_fee))
-        };
+			let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
+			Ok((slot, timestamp, dynamic_fee))
+		};
 
-        let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _>(
-            sc_consensus_aura::StartAuraParams {
-                slot_duration,
-                client,
-                select_chain,
-                block_import,
-                proposer_factory,
-                sync_oracle: network.clone(),
-                justification_sync_link: network.clone(),
-                create_inherent_data_providers,
-                force_authoring,
-                backoff_authoring_blocks: Option::<()>::None,
-                keystore: keystore_container.sync_keystore(),
-                block_proposal_slot_portion: sc_consensus_aura::SlotProportion::new(2f32 / 3f32),
-                max_block_proposal_slot_portion: None,
-                telemetry: telemetry.as_ref().map(|x| x.handle()),
-                compatibility_mode: sc_consensus_aura::CompatibilityMode::None,
-            },
-        )?;
-        // the AURA authoring task is considered essential, i.e. if it
-        // fails we take down the service with it.
-        task_manager
-            .spawn_essential_handle()
-            .spawn_blocking("aura", Some("block-authoring"), aura);
-    }
+		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _>(
+			sc_consensus_aura::StartAuraParams {
+				slot_duration,
+				client,
+				select_chain,
+				block_import,
+				proposer_factory,
+				sync_oracle: network.clone(),
+				justification_sync_link: network.clone(),
+				create_inherent_data_providers,
+				force_authoring,
+				backoff_authoring_blocks: Option::<()>::None,
+				keystore: keystore_container.sync_keystore(),
+				block_proposal_slot_portion: sc_consensus_aura::SlotProportion::new(2f32 / 3f32),
+				max_block_proposal_slot_portion: None,
+				telemetry: telemetry.as_ref().map(|x| x.handle()),
+				compatibility_mode: sc_consensus_aura::CompatibilityMode::None,
+			},
+		)?;
+		// the AURA authoring task is considered essential, i.e. if it
+		// fails we take down the service with it.
+		task_manager
+			.spawn_essential_handle()
+			.spawn_blocking("aura", Some("block-authoring"), aura);
+	}
 
-    if enable_grandpa {
-        // if the node isn't actively participating in consensus then it doesn't
-        // need a keystore, regardless of which protocol we use below.
-        let keystore = if role.is_authority() {
-            Some(keystore_container.sync_keystore())
-        } else {
-            None
-        };
+	if enable_grandpa {
+		// if the node isn't actively participating in consensus then it doesn't
+		// need a keystore, regardless of which protocol we use below.
+		let keystore = if role.is_authority() {
+			Some(keystore_container.sync_keystore())
+		} else {
+			None
+		};
 
-        let grandpa_config = sc_finality_grandpa::Config {
-            // FIXME #1578 make this available through chainspec
-            gossip_duration: Duration::from_millis(333),
-            justification_period: 512,
-            name: Some(name),
-            observer_enabled: false,
-            keystore,
-            local_role: role,
-            telemetry: telemetry.as_ref().map(|x| x.handle()),
-            protocol_name: grandpa_protocol_name,
-        };
+		let grandpa_config = sc_finality_grandpa::Config {
+			// FIXME #1578 make this available through chainspec
+			gossip_duration: Duration::from_millis(333),
+			justification_period: 512,
+			name: Some(name),
+			observer_enabled: false,
+			keystore,
+			local_role: role,
+			telemetry: telemetry.as_ref().map(|x| x.handle()),
+			protocol_name: grandpa_protocol_name,
+		};
 
-        // start the full GRANDPA voter
-        // NOTE: non-authorities could run the GRANDPA observer protocol, but at
-        // this point the full voter should provide better guarantees of block
-        // and vote data availability than the observer. The observer has not
-        // been tested extensively yet and having most nodes in a network run it
-        // could lead to finality stalls.
-        let grandpa_voter =
-            sc_finality_grandpa::run_grandpa_voter(sc_finality_grandpa::GrandpaParams {
-                config: grandpa_config,
-                link: grandpa_link,
-                network,
-                voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
-                prometheus_registry,
-                shared_voter_state: sc_finality_grandpa::SharedVoterState::empty(),
-                telemetry: telemetry.as_ref().map(|x| x.handle()),
-            })?;
+		// start the full GRANDPA voter
+		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
+		// this point the full voter should provide better guarantees of block
+		// and vote data availability than the observer. The observer has not
+		// been tested extensively yet and having most nodes in a network run it
+		// could lead to finality stalls.
+		let grandpa_voter =
+			sc_finality_grandpa::run_grandpa_voter(sc_finality_grandpa::GrandpaParams {
+				config: grandpa_config,
+				link: grandpa_link,
+				network,
+				voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
+				prometheus_registry,
+				shared_voter_state: sc_finality_grandpa::SharedVoterState::empty(),
+				telemetry: telemetry.as_ref().map(|x| x.handle()),
+			})?;
 
-        // the GRANDPA voter task is considered infallible, i.e.
-        // if it fails we take down the service with it.
-        task_manager
-            .spawn_essential_handle()
-            .spawn_blocking("grandpa-voter", None, grandpa_voter);
-    }
+		// the GRANDPA voter task is considered infallible, i.e.
+		// if it fails we take down the service with it.
+		task_manager
+			.spawn_essential_handle()
+			.spawn_blocking("grandpa-voter", None, grandpa_voter);
+	}
 
-    network_starter.start_network();
-    Ok(task_manager)
+	network_starter.start_network();
+	Ok(task_manager)
 }
 
 fn run_manual_seal_authorship<RuntimeApi, Executor>(
-    eth_config: &EthConfiguration,
-    sealing: Sealing,
-    client: Arc<FullClient<RuntimeApi, Executor>>,
-    transaction_pool: Arc<FullPool<FullClient<RuntimeApi, Executor>>>,
-    select_chain: FullSelectChain,
-    block_import: BoxBlockImport<FullClient<RuntimeApi, Executor>>,
-    task_manager: &TaskManager,
-    prometheus_registry: Option<&Registry>,
-    telemetry: Option<&Telemetry>,
-    commands_stream: mpsc::Receiver<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>,
+	eth_config: &EthConfiguration,
+	sealing: Sealing,
+	client: Arc<FullClient<RuntimeApi, Executor>>,
+	transaction_pool: Arc<FullPool<FullClient<RuntimeApi, Executor>>>,
+	select_chain: FullSelectChain,
+	block_import: BoxBlockImport<FullClient<RuntimeApi, Executor>>,
+	task_manager: &TaskManager,
+	prometheus_registry: Option<&Registry>,
+	telemetry: Option<&Telemetry>,
+	commands_stream: mpsc::Receiver<sc_consensus_manual_seal::rpc::EngineCommand<Hash>>,
 ) -> Result<(), ServiceError>
 where
-    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
-    RuntimeApi: Send + Sync + 'static,
-    RuntimeApi::RuntimeApi:
-        RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>>,
+	RuntimeApi: Send + Sync + 'static,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection<StateBackend = StateBackendFor<FullBackend, Block>>,
+	Executor: NativeExecutionDispatch + 'static,
 {
-    let proposer_factory = sc_basic_authorship::ProposerFactory::new(
-        task_manager.spawn_handle(),
-        client.clone(),
-        transaction_pool.clone(),
-        prometheus_registry,
-        telemetry.as_ref().map(|x| x.handle()),
-    );
+	let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+		task_manager.spawn_handle(),
+		client.clone(),
+		transaction_pool.clone(),
+		prometheus_registry,
+		telemetry.as_ref().map(|x| x.handle()),
+	);
 
-    thread_local!(static TIMESTAMP: RefCell<u64> = RefCell::new(0));
+	thread_local!(static TIMESTAMP: RefCell<u64> = RefCell::new(0));
 
-    /// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
-    /// Each call will increment timestamp by slot_duration making Aura think time has passed.
-    struct MockTimestampInherentDataProvider;
+	/// Provide a mock duration starting at 0 in millisecond for timestamp inherent.
+	/// Each call will increment timestamp by slot_duration making Aura think time has passed.
+	struct MockTimestampInherentDataProvider;
 
-    #[async_trait::async_trait]
-    impl sp_inherents::InherentDataProvider for MockTimestampInherentDataProvider {
-        async fn provide_inherent_data(
-            &self,
-            inherent_data: &mut sp_inherents::InherentData,
-        ) -> Result<(), sp_inherents::Error> {
-            TIMESTAMP.with(|x| {
-                *x.borrow_mut() += stabilty_runtime::SLOT_DURATION;
-                inherent_data.put_data(sp_timestamp::INHERENT_IDENTIFIER, &*x.borrow())
-            })
-        }
+	#[async_trait::async_trait]
+	impl sp_inherents::InherentDataProvider for MockTimestampInherentDataProvider {
+		async fn provide_inherent_data(
+			&self,
+			inherent_data: &mut sp_inherents::InherentData,
+		) -> Result<(), sp_inherents::Error> {
+			TIMESTAMP.with(|x| {
+				*x.borrow_mut() += stabilty_runtime::SLOT_DURATION;
+				inherent_data.put_data(sp_timestamp::INHERENT_IDENTIFIER, &*x.borrow())
+			})
+		}
 
-        async fn try_handle_error(
-            &self,
-            _identifier: &sp_inherents::InherentIdentifier,
-            _error: &[u8],
-        ) -> Option<Result<(), sp_inherents::Error>> {
-            // The pallet never reports error.
-            None
-        }
-    }
+		async fn try_handle_error(
+			&self,
+			_identifier: &sp_inherents::InherentIdentifier,
+			_error: &[u8],
+		) -> Option<Result<(), sp_inherents::Error>> {
+			// The pallet never reports error.
+			None
+		}
+	}
 
-    let target_gas_price = eth_config.target_gas_price;
-    let create_inherent_data_providers = move |_, ()| async move {
-        let timestamp = MockTimestampInherentDataProvider;
-        let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
-        Ok((timestamp, dynamic_fee))
-    };
+	let target_gas_price = eth_config.target_gas_price;
+	let create_inherent_data_providers = move |_, ()| async move {
+		let timestamp = MockTimestampInherentDataProvider;
+		let dynamic_fee = fp_dynamic_fee::InherentDataProvider(U256::from(target_gas_price));
+		Ok((timestamp, dynamic_fee))
+	};
 
-    let manual_seal = match sealing {
-        Sealing::Manual => future::Either::Left(sc_consensus_manual_seal::run_manual_seal(
-            sc_consensus_manual_seal::ManualSealParams {
-                block_import,
-                env: proposer_factory,
-                client,
-                pool: transaction_pool,
-                commands_stream,
-                select_chain,
-                consensus_data_provider: None,
-                create_inherent_data_providers,
-            },
-        )),
-        Sealing::Instant => future::Either::Right(sc_consensus_manual_seal::run_instant_seal(
-            sc_consensus_manual_seal::InstantSealParams {
-                block_import,
-                env: proposer_factory,
-                client,
-                pool: transaction_pool,
-                select_chain,
-                consensus_data_provider: None,
-                create_inherent_data_providers,
-            },
-        )),
-    };
+	let manual_seal = match sealing {
+		Sealing::Manual => future::Either::Left(sc_consensus_manual_seal::run_manual_seal(
+			sc_consensus_manual_seal::ManualSealParams {
+				block_import,
+				env: proposer_factory,
+				client,
+				pool: transaction_pool,
+				commands_stream,
+				select_chain,
+				consensus_data_provider: None,
+				create_inherent_data_providers,
+			},
+		)),
+		Sealing::Instant => future::Either::Right(sc_consensus_manual_seal::run_instant_seal(
+			sc_consensus_manual_seal::InstantSealParams {
+				block_import,
+				env: proposer_factory,
+				client,
+				pool: transaction_pool,
+				select_chain,
+				consensus_data_provider: None,
+				create_inherent_data_providers,
+			},
+		)),
+	};
 
-    // we spawn the future on a background thread managed by service.
-    task_manager
-        .spawn_essential_handle()
-        .spawn_blocking("manual-seal", None, manual_seal);
-    Ok(())
+	// we spawn the future on a background thread managed by service.
+	task_manager
+		.spawn_essential_handle()
+		.spawn_blocking("manual-seal", None, manual_seal);
+	Ok(())
 }
 
 pub fn build_full(
-    config: Configuration,
-    eth_config: EthConfiguration,
-    sealing: Option<Sealing>,
+	config: Configuration,
+	eth_config: EthConfiguration,
+	sealing: Option<Sealing>,
 ) -> Result<TaskManager, ServiceError> {
-    new_full::<stabilty_runtime::RuntimeApi, TemplateRuntimeExecutor>(config, eth_config, sealing)
+	new_full::<stabilty_runtime::RuntimeApi, TemplateRuntimeExecutor>(config, eth_config, sealing)
 }
 
 pub fn new_chain_ops(
-    mut config: &mut Configuration,
-    eth_config: &EthConfiguration,
+	mut config: &mut Configuration,
+	eth_config: &EthConfiguration,
 ) -> Result<
-    (
-        Arc<Client>,
-        Arc<FullBackend>,
-        BasicQueue<Block, PrefixedMemoryDB<BlakeTwo256>>,
-        TaskManager,
-        Arc<FrontierBackend>,
-    ),
-    ServiceError,
+	(
+		Arc<Client>,
+		Arc<FullBackend>,
+		BasicQueue<Block, PrefixedMemoryDB<BlakeTwo256>>,
+		TaskManager,
+		Arc<FrontierBackend>,
+	),
+	ServiceError,
 > {
-    config.keystore = sc_service::config::KeystoreConfig::InMemory;
-    let PartialComponents {
-        client,
-        backend,
-        import_queue,
-        task_manager,
-        other,
-        ..
-    } = new_partial::<stabilty_runtime::RuntimeApi, TemplateRuntimeExecutor, _>(
-        config,
-        eth_config,
-        build_aura_grandpa_import_queue,
-    )?;
-    Ok((client, backend, import_queue, task_manager, other.3))
+	config.keystore = sc_service::config::KeystoreConfig::InMemory;
+	let PartialComponents {
+		client,
+		backend,
+		import_queue,
+		task_manager,
+		other,
+		..
+	} = new_partial::<stabilty_runtime::RuntimeApi, TemplateRuntimeExecutor, _>(
+		config,
+		eth_config,
+		build_aura_grandpa_import_queue,
+	)?;
+	Ok((client, backend, import_queue, task_manager, other.3))
 }

--- a/pallets/root-controller/src/lib.rs
+++ b/pallets/root-controller/src/lib.rs
@@ -17,44 +17,44 @@ use frame_support::traits::UnfilteredDispatchable;
 #[frame_support::pallet]
 
 pub mod pallet {
-    use super::*;
-    use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
-    #[pallet::pallet]
-    #[pallet::without_storage_info]
-    pub struct Pallet<T>(_);
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
 
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
-        type ControlOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-        type RuntimeCall: Parameter
-            + UnfilteredDispatchable<RuntimeOrigin = Self::RuntimeOrigin>
-            + GetDispatchInfo;
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-    }
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type ControlOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+		type RuntimeCall: Parameter
+			+ UnfilteredDispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+			+ GetDispatchInfo;
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
 
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {
-        /// A dispatch_as_root just took place. \[result\]
-        DispatchAsRootOccurred { dispatch_result: DispatchResult },
-    }
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A dispatch_as_root just took place. \[result\]
+		DispatchAsRootOccurred { dispatch_result: DispatchResult },
+	}
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
-        #[pallet::call_index(0)]
-        #[pallet::weight(0)]
-        pub fn dispatch_as_root(
-            origin: OriginFor<T>,
-            call: Box<<T as Config>::RuntimeCall>,
-        ) -> DispatchResultWithPostInfo {
-            T::ControlOrigin::ensure_origin(origin)?;
-            let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
-            Self::deposit_event(Event::DispatchAsRootOccurred {
-                dispatch_result: res.map(|_| ()).map_err(|e| e.error),
-            });
-            Ok(Pays::No.into())
-        }
-    }
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(0)]
+		pub fn dispatch_as_root(
+			origin: OriginFor<T>,
+			call: Box<<T as Config>::RuntimeCall>,
+		) -> DispatchResultWithPostInfo {
+			T::ControlOrigin::ensure_origin(origin)?;
+			let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Root.into());
+			Self::deposit_event(Event::DispatchAsRootOccurred {
+				dispatch_result: res.map(|_| ()).map_err(|e| e.error),
+			});
+			Ok(Pays::No.into())
+		}
+	}
 }

--- a/pallets/root-controller/src/mock.rs
+++ b/pallets/root-controller/src/mock.rs
@@ -8,8 +8,8 @@ use frame_support::traits::{ConstU32, ConstU64, Contains};
 use sp_core::H256;
 use sp_io;
 use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -17,105 +17,105 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 
 pub struct BlockEverything;
 impl Contains<RuntimeCall> for BlockEverything {
-    fn contains(_: &RuntimeCall) -> bool {
-        false
-    }
+	fn contains(_: &RuntimeCall) -> bool {
+		false
+	}
 }
 
 impl frame_system::Config for Test {
-    type BaseCallFilter = BlockEverything;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type DbWeight = ();
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeCall = RuntimeCall;
-    type Index = u64;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = u64;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = ConstU64<250>;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type SS58Prefix = ();
-    type OnSetCode = ();
-    type MaxConsumers = ConstU32<16>;
+	type BaseCallFilter = BlockEverything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
 }
 
 ord_parameter_types! {
-    pub const AllowedAccountId: u64 = 1;
-    pub const NotAllowedAccountId: u64 = 2;
+	pub const AllowedAccountId: u64 = 1;
+	pub const NotAllowedAccountId: u64 = 2;
 }
 
 impl Config for Test {
-    type ControlOrigin = frame_system::EnsureSignedBy<AllowedAccountId, u64>;
-    type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
+	type ControlOrigin = frame_system::EnsureSignedBy<AllowedAccountId, u64>;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
 }
 
 // Logger module to track execution.
 #[frame_support::pallet]
 pub mod logger {
 
-    use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
-    #[pallet::config]
-    pub trait Config: frame_system::Config {}
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
 
-    #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
-    pub struct Pallet<T>(PhantomData<T>);
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
-        #[pallet::call_index(0)]
-        #[pallet::weight(0)]
-        pub fn privileged_i32_log(origin: OriginFor<T>, i: i32) -> DispatchResultWithPostInfo {
-            // Ensure that the `origin` is `Root`.
-            ensure_root(origin)?;
-            <I32Log<T>>::try_append(i).map_err(|_| "could not append")?;
-            Ok(().into())
-        }
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(0)]
+		pub fn privileged_i32_log(origin: OriginFor<T>, i: i32) -> DispatchResultWithPostInfo {
+			// Ensure that the `origin` is `Root`.
+			ensure_root(origin)?;
+			<I32Log<T>>::try_append(i).map_err(|_| "could not append")?;
+			Ok(().into())
+		}
 
-        #[pallet::call_index(1)]
-        #[pallet::weight(0)]
-        pub fn force_fail_log(_: OriginFor<T>) -> DispatchResultWithPostInfo {
-            Err(DispatchError::BadOrigin.into())
-        }
-    }
+		#[pallet::call_index(1)]
+		#[pallet::weight(0)]
+		pub fn force_fail_log(_: OriginFor<T>) -> DispatchResultWithPostInfo {
+			Err(DispatchError::BadOrigin.into())
+		}
+	}
 
-    #[pallet::storage]
-    #[pallet::getter(fn i32_log)]
-    pub(super) type I32Log<T> = StorageValue<_, BoundedVec<i32, ConstU32<1_000>>, ValueQuery>;
+	#[pallet::storage]
+	#[pallet::getter(fn i32_log)]
+	pub(super) type I32Log<T> = StorageValue<_, BoundedVec<i32, ConstU32<1_000>>, ValueQuery>;
 }
 
 impl logger::Config for Test {}
 
 frame_support::construct_runtime!(
-    pub enum Test
-    where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic, {
-            System: frame_system,
-            RootController: root_controller,
-            Logger: logger,
-        }
+	pub enum Test
+	where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic, {
+			System: frame_system,
+			RootController: root_controller,
+			Logger: logger,
+		}
 );
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    let t = frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap();
-    t.into()
+	let t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+	t.into()
 }
 
 pub type LoggerCall = logger::Call<Test>;

--- a/pallets/root-controller/src/tests.rs
+++ b/pallets/root-controller/src/tests.rs
@@ -1,77 +1,77 @@
 use super::*;
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchError};
 use mock::{
-    new_test_ext, AllowedAccountId, Logger, LoggerCall, NotAllowedAccountId, RootController,
-    RuntimeCall, RuntimeEvent as TestEvent, RuntimeOrigin, System,
+	new_test_ext, AllowedAccountId, Logger, LoggerCall, NotAllowedAccountId, RootController,
+	RuntimeCall, RuntimeEvent as TestEvent, RuntimeOrigin, System,
 };
 
 #[test]
 fn test_setup_works() {
-    new_test_ext().execute_with(|| {
-        assert!(Logger::i32_log().is_empty());
-    });
+	new_test_ext().execute_with(|| {
+		assert!(Logger::i32_log().is_empty());
+	});
 }
 
 #[test]
 fn test_dispatch_as_root_signed_from_allowed_origin() {
-    new_test_ext().execute_with(|| {
-        let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
-            i: 42,
-        }));
-        assert_ok!(RootController::dispatch_as_root(
-            RuntimeOrigin::signed(AllowedAccountId::get()),
-            call
-        ));
-        assert_eq!(Logger::i32_log(), vec![42i32]);
-    });
+	new_test_ext().execute_with(|| {
+		let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
+			i: 42,
+		}));
+		assert_ok!(RootController::dispatch_as_root(
+			RuntimeOrigin::signed(AllowedAccountId::get()),
+			call
+		));
+		assert_eq!(Logger::i32_log(), vec![42i32]);
+	});
 }
 
 #[test]
 fn test_dispatch_as_root_signed_from_not_allowed() {
-    new_test_ext().execute_with(|| {
-        let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
-            i: 42,
-        }));
-        assert_noop!(
-            RootController::dispatch_as_root(
-                RuntimeOrigin::signed(NotAllowedAccountId::get()),
-                call
-            ),
-            DispatchError::BadOrigin
-        );
-    });
+	new_test_ext().execute_with(|| {
+		let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
+			i: 42,
+		}));
+		assert_noop!(
+			RootController::dispatch_as_root(
+				RuntimeOrigin::signed(NotAllowedAccountId::get()),
+				call
+			),
+			DispatchError::BadOrigin
+		);
+	});
 }
 
 #[test]
 fn test_dispatch_as_root_emits_empty_when_dispatch_success() {
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
-        let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
-            i: 42,
-        }));
-        assert_ok!(RootController::dispatch_as_root(
-            RuntimeOrigin::signed(AllowedAccountId::get()),
-            call
-        ));
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let call = Box::new(RuntimeCall::Logger(LoggerCall::privileged_i32_log {
+			i: 42,
+		}));
+		assert_ok!(RootController::dispatch_as_root(
+			RuntimeOrigin::signed(AllowedAccountId::get()),
+			call
+		));
 
-        System::assert_has_event(TestEvent::RootController(Event::DispatchAsRootOccurred {
-            dispatch_result: Ok(()),
-        }));
-    });
+		System::assert_has_event(TestEvent::RootController(Event::DispatchAsRootOccurred {
+			dispatch_result: Ok(()),
+		}));
+	});
 }
 
 #[test]
 fn test_dispatch_as_root_emits_dispatch_error_when_dispatch_fails() {
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
-        let call = Box::new(RuntimeCall::Logger(LoggerCall::force_fail_log {}));
-        assert_ok!(RootController::dispatch_as_root(
-            RuntimeOrigin::signed(AllowedAccountId::get()),
-            call
-        ));
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		let call = Box::new(RuntimeCall::Logger(LoggerCall::force_fail_log {}));
+		assert_ok!(RootController::dispatch_as_root(
+			RuntimeOrigin::signed(AllowedAccountId::get()),
+			call
+		));
 
-        System::assert_has_event(TestEvent::RootController(Event::DispatchAsRootOccurred {
-            dispatch_result: Err(DispatchError::BadOrigin),
-        }));
-    });
+		System::assert_has_event(TestEvent::RootController(Event::DispatchAsRootOccurred {
+			dispatch_result: Err(DispatchError::BadOrigin),
+		}));
+	});
 }

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -22,157 +22,157 @@ use sp_std::vec::Vec;
 
 /// EIP2612 permit typehash.
 pub const PERMIT_TYPEHASH: [u8; 32] = keccak256!(
-    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+	"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
 );
 
 /// EIP2612 permit domain used to compute an individualized domain separator.
 const PERMIT_DOMAIN: [u8; 32] = keccak256!(
-    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
 pub struct Eip2612<Runtime, Metadata, DefaultOwner: Get<H160> + 'static, Instance = ()>(
-    PhantomData<(Runtime, Metadata, DefaultOwner, Instance)>,
+	PhantomData<(Runtime, Metadata, DefaultOwner, Instance)>,
 );
 
 impl<Runtime, Metadata, DefaultOwner, Instance> Eip2612<Runtime, Metadata, DefaultOwner, Instance>
 where
-    Metadata: Erc20Metadata,
-    DefaultOwner: Get<H160> + 'static,
-    Instance: InstanceToPrefix + 'static,
-    Runtime: pallet_balances::Config<Instance> + pallet_evm::Config + pallet_timestamp::Config,
-    Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
-    Runtime::RuntimeCall: From<pallet_balances::Call<Runtime, Instance>>,
-    <Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<Runtime::AccountId>>,
-    BalanceOf<Runtime, Instance>: TryFrom<U256> + Into<U256>,
-    <Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
+	Metadata: Erc20Metadata,
+	DefaultOwner: Get<H160> + 'static,
+	Instance: InstanceToPrefix + 'static,
+	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config + pallet_timestamp::Config,
+	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	Runtime::RuntimeCall: From<pallet_balances::Call<Runtime, Instance>>,
+	<Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<Runtime::AccountId>>,
+	BalanceOf<Runtime, Instance>: TryFrom<U256> + Into<U256>,
+	<Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
 {
-    pub fn compute_domain_separator(address: H160) -> [u8; 32] {
-        let name: H256 = keccak_256(Metadata::name().as_bytes()).into();
+	pub fn compute_domain_separator(address: H160) -> [u8; 32] {
+		let name: H256 = keccak_256(Metadata::name().as_bytes()).into();
 
-        let version: H256 = keccak256!("1").into();
+		let version: H256 = keccak256!("1").into();
 
-        let chain_id: U256 = Runtime::ChainId::get().into();
+		let chain_id: U256 = Runtime::ChainId::get().into();
 
-        let domain_separator_inner = EvmDataWriter::new()
-            .write(H256::from(PERMIT_DOMAIN))
-            .write(name)
-            .write(version)
-            .write(chain_id)
-            .write(Address(address))
-            .build();
+		let domain_separator_inner = EvmDataWriter::new()
+			.write(H256::from(PERMIT_DOMAIN))
+			.write(name)
+			.write(version)
+			.write(chain_id)
+			.write(Address(address))
+			.build();
 
-        keccak_256(&domain_separator_inner).into()
-    }
+		keccak_256(&domain_separator_inner).into()
+	}
 
-    pub fn generate_permit(
-        address: H160,
-        owner: H160,
-        spender: H160,
-        value: U256,
-        nonce: U256,
-        deadline: U256,
-    ) -> [u8; 32] {
-        let domain_separator = Self::compute_domain_separator(address);
+	pub fn generate_permit(
+		address: H160,
+		owner: H160,
+		spender: H160,
+		value: U256,
+		nonce: U256,
+		deadline: U256,
+	) -> [u8; 32] {
+		let domain_separator = Self::compute_domain_separator(address);
 
-        let permit_content = EvmDataWriter::new()
-            .write(H256::from(PERMIT_TYPEHASH))
-            .write(Address(owner))
-            .write(Address(spender))
-            .write(value)
-            .write(nonce)
-            .write(deadline)
-            .build();
-        let permit_content = keccak_256(&permit_content);
+		let permit_content = EvmDataWriter::new()
+			.write(H256::from(PERMIT_TYPEHASH))
+			.write(Address(owner))
+			.write(Address(spender))
+			.write(value)
+			.write(nonce)
+			.write(deadline)
+			.build();
+		let permit_content = keccak_256(&permit_content);
 
-        let mut pre_digest = Vec::with_capacity(2 + 32 + 32);
-        pre_digest.extend_from_slice(b"\x19\x01");
-        pre_digest.extend_from_slice(&domain_separator);
-        pre_digest.extend_from_slice(&permit_content);
-        keccak_256(&pre_digest)
-    }
+		let mut pre_digest = Vec::with_capacity(2 + 32 + 32);
+		pre_digest.extend_from_slice(b"\x19\x01");
+		pre_digest.extend_from_slice(&domain_separator);
+		pre_digest.extend_from_slice(&permit_content);
+		keccak_256(&pre_digest)
+	}
 
-    // Translated from
-    // https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
-    pub(crate) fn permit(
-        handle: &mut impl PrecompileHandle,
-        owner: Address,
-        spender: Address,
-        value: U256,
-        deadline: U256,
-        v: u8,
-        r: H256,
-        s: H256,
-    ) -> EvmResult {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+	// Translated from
+	// https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol#L81
+	pub(crate) fn permit(
+		handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+		value: U256,
+		deadline: U256,
+		v: u8,
+		r: H256,
+		s: H256,
+	) -> EvmResult {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
-        let owner: H160 = owner.into();
-        let spender: H160 = spender.into();
+		let owner: H160 = owner.into();
+		let spender: H160 = spender.into();
 
-        // pallet_timestamp is in ms while Ethereum use second timestamps.
-        let timestamp: U256 = (pallet_timestamp::Pallet::<Runtime>::get()).into() / 1000;
+		// pallet_timestamp is in ms while Ethereum use second timestamps.
+		let timestamp: U256 = (pallet_timestamp::Pallet::<Runtime>::get()).into() / 1000;
 
-        ensure!(deadline >= timestamp, revert("Permit expired"));
+		ensure!(deadline >= timestamp, revert("Permit expired"));
 
-        let nonce = NoncesStorage::<Instance>::get(owner);
+		let nonce = NoncesStorage::<Instance>::get(owner);
 
-        let permit = Self::generate_permit(
-            handle.context().address,
-            owner,
-            spender,
-            value,
-            nonce,
-            deadline,
-        );
+		let permit = Self::generate_permit(
+			handle.context().address,
+			owner,
+			spender,
+			value,
+			nonce,
+			deadline,
+		);
 
-        let mut sig = [0u8; 65];
-        sig[0..32].copy_from_slice(&r.as_bytes());
-        sig[32..64].copy_from_slice(&s.as_bytes());
-        sig[64] = v;
+		let mut sig = [0u8; 65];
+		sig[0..32].copy_from_slice(&r.as_bytes());
+		sig[32..64].copy_from_slice(&s.as_bytes());
+		sig[64] = v;
 
-        let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)
-            .map_err(|_| revert("Invalid permit"))?;
-        let signer = H160::from(H256::from_slice(keccak_256(&signer).as_slice()));
+		let signer = sp_io::crypto::secp256k1_ecdsa_recover(&sig, &permit)
+			.map_err(|_| revert("Invalid permit"))?;
+		let signer = H160::from(H256::from_slice(keccak_256(&signer).as_slice()));
 
-        ensure!(
-            signer != H160::zero() && signer == owner,
-            revert("Invalid permit")
-        );
+		ensure!(
+			signer != H160::zero() && signer == owner,
+			revert("Invalid permit")
+		);
 
-        NoncesStorage::<Instance>::insert(owner, nonce + U256::one());
+		NoncesStorage::<Instance>::insert(owner, nonce + U256::one());
 
-        {
-            let amount =
+		{
+			let amount =
 				Erc20BalancesPrecompile::<Runtime, Metadata, DefaultOwner, Instance>::u256_to_amount(value)
 					.unwrap_or_else(|_| Bounded::max_value());
 
-            let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
-            let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
-            ApprovesStorage::<Runtime, Instance>::insert(owner, spender, amount);
-        }
+			let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
+			let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
+			ApprovesStorage::<Runtime, Instance>::insert(owner, spender, amount);
+		}
 
-        log3(
-            handle.context().address,
-            SELECTOR_LOG_APPROVAL,
-            owner,
-            spender,
-            EvmDataWriter::new().write(value).build(),
-        )
-        .record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			owner,
+			spender,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    pub(crate) fn nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+	pub(crate) fn nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
-        let owner: H160 = owner.into();
+		let owner: H160 = owner.into();
 
-        Ok(NoncesStorage::<Instance>::get(owner))
-    }
+		Ok(NoncesStorage::<Instance>::get(owner))
+	}
 
-    pub(crate) fn domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+	pub(crate) fn domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
-        Ok(Self::compute_domain_separator(handle.context().address).into())
-    }
+		Ok(Self::compute_domain_separator(handle.context().address).into())
+	}
 }

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -25,23 +25,23 @@ use fp_evm::PrecompileHandle;
 use frame_support::parameter_types;
 use frame_support::sp_runtime::SaturatedConversion;
 use frame_support::{
-    dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
-    sp_runtime::traits::{Bounded, CheckedSub, StaticLookup},
-    storage::types::{StorageDoubleMap, StorageMap, StorageValue, ValueQuery},
-    traits::{fungible::Mutate, StorageInstance},
-    Blake2_128Concat,
+	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+	sp_runtime::traits::{Bounded, CheckedSub, StaticLookup},
+	storage::types::{StorageDoubleMap, StorageMap, StorageValue, ValueQuery},
+	traits::{fungible::Mutate, StorageInstance},
+	Blake2_128Concat,
 };
 use pallet_balances::pallet::{
-    Instance1, Instance10, Instance11, Instance12, Instance13, Instance14, Instance15, Instance16,
-    Instance2, Instance3, Instance4, Instance5, Instance6, Instance7, Instance8, Instance9,
+	Instance1, Instance10, Instance11, Instance12, Instance13, Instance14, Instance15, Instance16,
+	Instance2, Instance3, Instance4, Instance5, Instance6, Instance7, Instance8, Instance9,
 };
 use pallet_evm::AddressMapping;
 use precompile_utils::prelude::*;
 use sp_core::Get;
 use sp_core::{H160, H256, U256};
 use sp_std::{
-    convert::{TryFrom, TryInto},
-    marker::PhantomData,
+	convert::{TryFrom, TryInto},
+	marker::PhantomData,
 };
 
 mod eip2612;
@@ -70,78 +70,78 @@ pub const SELECTOR_LOG_NEW_OWNER: [u8; 32] = keccak256!("NewOwner(address)");
 /// Associates pallet Instance to a prefix used for the Approves storage.
 /// This trait is implemented for () and the 16 substrate Instance.
 pub trait InstanceToPrefix {
-    /// Prefix used for the Approves storage.
-    type ApprovesPrefix: StorageInstance;
+	/// Prefix used for the Approves storage.
+	type ApprovesPrefix: StorageInstance;
 
-    /// Prefix used for the Approves storage.
-    type NoncesPrefix: StorageInstance;
+	/// Prefix used for the Approves storage.
+	type NoncesPrefix: StorageInstance;
 
-    /// Prefix used for the Owner storage.
-    type OwnerPrefix: StorageInstance;
+	/// Prefix used for the Owner storage.
+	type OwnerPrefix: StorageInstance;
 
-    /// Prefix used for the ClaimableOwner storage.
-    type ClaimableOwnerPrefix: StorageInstance;
+	/// Prefix used for the ClaimableOwner storage.
+	type ClaimableOwnerPrefix: StorageInstance;
 }
 
 // We use a macro to implement the trait for () and the 16 substrate Instance.
 macro_rules! impl_prefix {
-    ($instance:ident, $name:literal) => {
-        // Using `paste!` we generate a dedicated module to avoid collisions
-        // between each instance `Approves` struct.
-        paste::paste! {
-            mod [<_impl_prefix_ $instance:snake>] {
-                use super::*;
+	($instance:ident, $name:literal) => {
+		// Using `paste!` we generate a dedicated module to avoid collisions
+		// between each instance `Approves` struct.
+		paste::paste! {
+			mod [<_impl_prefix_ $instance:snake>] {
+				use super::*;
 
-                pub struct Approves;
+				pub struct Approves;
 
-                impl StorageInstance for Approves {
-                    const STORAGE_PREFIX: &'static str = "Approves";
+				impl StorageInstance for Approves {
+					const STORAGE_PREFIX: &'static str = "Approves";
 
-                    fn pallet_prefix() -> &'static str {
-                        $name
-                    }
-                }
+					fn pallet_prefix() -> &'static str {
+						$name
+					}
+				}
 
-                pub struct Nonces;
+				pub struct Nonces;
 
-                impl StorageInstance for Nonces {
-                    const STORAGE_PREFIX: &'static str = "Nonces";
+				impl StorageInstance for Nonces {
+					const STORAGE_PREFIX: &'static str = "Nonces";
 
-                    fn pallet_prefix() -> &'static str {
-                        $name
-                    }
-                }
+					fn pallet_prefix() -> &'static str {
+						$name
+					}
+				}
 
-                pub struct Owner;
+				pub struct Owner;
 
-                impl StorageInstance for Owner {
-                    const STORAGE_PREFIX: &'static str = "Owner";
+				impl StorageInstance for Owner {
+					const STORAGE_PREFIX: &'static str = "Owner";
 
-                    fn pallet_prefix() -> &'static str {
-                        $name
-                    }
-                }
+					fn pallet_prefix() -> &'static str {
+						$name
+					}
+				}
 
-                pub struct ClaimableOwner;
+				pub struct ClaimableOwner;
 
-                impl StorageInstance for ClaimableOwner {
-                    const STORAGE_PREFIX: &'static str = "ClaimableOwner";
+				impl StorageInstance for ClaimableOwner {
+					const STORAGE_PREFIX: &'static str = "ClaimableOwner";
 
-                    fn pallet_prefix() -> &'static str {
-                        $name
-                    }
-                }
+					fn pallet_prefix() -> &'static str {
+						$name
+					}
+				}
 
 
-                impl InstanceToPrefix for $instance {
-                    type ApprovesPrefix = Approves;
-                    type NoncesPrefix = Nonces;
-                    type OwnerPrefix = Owner;
-                    type ClaimableOwnerPrefix = ClaimableOwner;
-                }
-            }
-        }
-    };
+				impl InstanceToPrefix for $instance {
+					type ApprovesPrefix = Approves;
+					type NoncesPrefix = Nonces;
+					type OwnerPrefix = Owner;
+					type ClaimableOwnerPrefix = ClaimableOwner;
+				}
+			}
+		}
+	};
 }
 
 // Since the macro expect a `ident` to be used with `paste!` we cannot provide `()` directly.
@@ -167,520 +167,520 @@ impl_prefix!(Instance16, "Erc20Instance16Balances");
 
 /// Alias for the Balance type for the provided Runtime and Instance.
 pub type BalanceOf<Runtime, Instance = ()> =
-    <Runtime as pallet_balances::Config<Instance>>::Balance;
+	<Runtime as pallet_balances::Config<Instance>>::Balance;
 
 /// Storage type used to store approvals, since `pallet_balances` doesn't
 /// handle this behavior.
 /// (Owner => Allowed => Amount)
 pub type ApprovesStorage<Runtime, Instance> = StorageDoubleMap<
-    <Instance as InstanceToPrefix>::ApprovesPrefix,
-    Blake2_128Concat,
-    <Runtime as frame_system::Config>::AccountId,
-    Blake2_128Concat,
-    <Runtime as frame_system::Config>::AccountId,
-    BalanceOf<Runtime, Instance>,
+	<Instance as InstanceToPrefix>::ApprovesPrefix,
+	Blake2_128Concat,
+	<Runtime as frame_system::Config>::AccountId,
+	Blake2_128Concat,
+	<Runtime as frame_system::Config>::AccountId,
+	BalanceOf<Runtime, Instance>,
 >;
 
 pub type OwnerStorage<Instance, DefaultOwner> =
-    StorageValue<<Instance as InstanceToPrefix>::OwnerPrefix, H160, ValueQuery, DefaultOwner>;
+	StorageValue<<Instance as InstanceToPrefix>::OwnerPrefix, H160, ValueQuery, DefaultOwner>;
 
 parameter_types! {
-    pub ZeroAddress:H160 = H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
+	pub ZeroAddress:H160 = H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
 }
 pub type ClaimableOwnerStorage<Instance> = StorageValue<
-    <Instance as InstanceToPrefix>::ClaimableOwnerPrefix,
-    H160,
-    ValueQuery,
-    ZeroAddress,
+	<Instance as InstanceToPrefix>::ClaimableOwnerPrefix,
+	H160,
+	ValueQuery,
+	ZeroAddress,
 >;
 
 /// Storage type used to store EIP2612 nonces.
 pub type NoncesStorage<Instance> = StorageMap<
-    <Instance as InstanceToPrefix>::NoncesPrefix,
-    // Owner
-    Blake2_128Concat,
-    H160,
-    // Nonce
-    U256,
-    ValueQuery,
+	<Instance as InstanceToPrefix>::NoncesPrefix,
+	// Owner
+	Blake2_128Concat,
+	H160,
+	// Nonce
+	U256,
+	ValueQuery,
 >;
 
 /// Metadata of an ERC20 token.
 pub trait Erc20Metadata {
-    /// Returns the name of the token.
-    fn name() -> &'static str;
+	/// Returns the name of the token.
+	fn name() -> &'static str;
 
-    /// Returns the symbol of the token.
-    fn symbol() -> &'static str;
+	/// Returns the symbol of the token.
+	fn symbol() -> &'static str;
 
-    /// Returns the decimals places of the token.
-    fn decimals() -> u8;
+	/// Returns the decimals places of the token.
+	fn decimals() -> u8;
 
-    /// Must return `true` only if it represents the main native currency of
-    /// the network. It must be the currency used in `pallet_evm`.
-    fn is_native_currency() -> bool;
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool;
 }
 
 /// Precompile exposing a pallet_balance as an ERC20.
 /// Multiple precompiles can support instances of pallet_balance.
 /// The precompile uses an additional storage to store approvals.
 pub struct Erc20BalancesPrecompile<
-    Runtime,
-    Metadata: Erc20Metadata,
-    DefaultOwner: Get<H160> + 'static,
-    Instance: 'static = (),
+	Runtime,
+	Metadata: Erc20Metadata,
+	DefaultOwner: Get<H160> + 'static,
+	Instance: 'static = (),
 >(PhantomData<(Runtime, Metadata, DefaultOwner, Instance)>);
 
 #[precompile_utils::precompile]
 impl<Runtime, Metadata, DefaultOwner, Instance>
-    Erc20BalancesPrecompile<Runtime, Metadata, DefaultOwner, Instance>
+	Erc20BalancesPrecompile<Runtime, Metadata, DefaultOwner, Instance>
 where
-    DefaultOwner: Get<H160> + 'static,
-    Metadata: Erc20Metadata,
-    Instance: InstanceToPrefix + 'static,
-    Runtime: pallet_balances::Config<Instance> + pallet_evm::Config + pallet_timestamp::Config,
-    Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
-    Runtime::RuntimeCall: From<pallet_balances::Call<Runtime, Instance>>,
-    <Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<Runtime::AccountId>>,
-    BalanceOf<Runtime, Instance>: TryFrom<U256> + Into<U256>,
-    <Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
+	DefaultOwner: Get<H160> + 'static,
+	Metadata: Erc20Metadata,
+	Instance: InstanceToPrefix + 'static,
+	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config + pallet_timestamp::Config,
+	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	Runtime::RuntimeCall: From<pallet_balances::Call<Runtime, Instance>>,
+	<Runtime::RuntimeCall as Dispatchable>::RuntimeOrigin: From<Option<Runtime::AccountId>>,
+	BalanceOf<Runtime, Instance>: TryFrom<U256> + Into<U256>,
+	<Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
 {
-    #[precompile::public("owner()")]
-    #[precompile::view]
-    fn owner(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        Ok(OwnerStorage::<Instance, DefaultOwner>::get().into())
-    }
-
-    #[precompile::public("pendingOwner()")]
-    #[precompile::view]
-    fn pending_owner(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        Ok(ClaimableOwnerStorage::<Instance>::get().into())
-    }
-
-    #[precompile::public("mintTo(address,uint256)")]
-    fn mint_to(handle: &mut impl PrecompileHandle, to: Address, amount: U256) -> EvmResult {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-
-        let sender = handle.context().caller;
-        let owner = OwnerStorage::<Instance, DefaultOwner>::get();
-
-        handle.record_log_costs_manual(3, 32)?;
-
-        let zero_address =
-            H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
-
-        if sender != owner {
-            Err(revert("sender is not owner"))
-        } else {
-            let target: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to.into());
-
-            pallet_balances::Pallet::<Runtime, Instance>::mint_into(
-                &target,
-                amount.saturated_into(),
-            )
-            .or_else(|_| Err(revert("mint operation overflow account balance")))?;
-
-            log3(
-                handle.context().address,
-                SELECTOR_LOG_TRANSFER,
-                zero_address,
-                Into::<H160>::into(to),
-                EvmDataWriter::new().write(amount).build(),
-            )
-            .record(handle)?;
-
-            Ok(())
-        }
-    }
-
-    #[precompile::public("burnFrom(address,uint256)")]
-    fn burn_from(handle: &mut impl PrecompileHandle, to: Address, amount: U256) -> EvmResult {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-
-        let sender = handle.context().caller;
-        let owner = OwnerStorage::<Instance, DefaultOwner>::get();
-
-        handle.record_log_costs_manual(3, 32)?;
-
-        let zero_address =
-            H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
-
-        if sender != owner {
-            Err(revert("sender is not owner"))
-        } else {
-            let target: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to.into());
-
-            pallet_balances::Pallet::<Runtime, Instance>::burn_from(
-                &target,
-                amount.saturated_into(),
-            )
-            .or_else(|_| return Err(revert("not enough balance to burn")))?;
-
-            log3(
-                handle.context().address,
-                SELECTOR_LOG_TRANSFER,
-                Into::<H160>::into(to),
-                zero_address,
-                EvmDataWriter::new().write(amount).build(),
-            )
-            .record(handle)?;
-
-            Ok(())
-        }
-    }
-
-    #[precompile::public("transferOwnership(address)")]
-    fn transfer_ownership(handle: &mut impl PrecompileHandle, new_owner: Address) -> EvmResult {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        let sender = handle.context().caller;
-        let owner = OwnerStorage::<Instance, DefaultOwner>::get();
-
-        if sender != owner {
-            return Err(revert("sender is not owner"));
-        }
-
-        ClaimableOwnerStorage::<Instance>::mutate(move |claimable_owner| {
-            *claimable_owner = new_owner.into();
-        });
-
-        Ok(())
-    }
-
-    #[precompile::public("acceptOwnership()")]
-    fn claim_ownership(handle: &mut impl PrecompileHandle) -> EvmResult {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-
-        handle.record_log_costs_manual(1, 32)?;
-
-        let sender = handle.context().caller;
-
-        let target_new_owner = ClaimableOwnerStorage::<Instance>::get();
-
-        if target_new_owner != sender {
-            return Err(revert("target owner is not the claimer"));
-        }
-
-        ClaimableOwnerStorage::<Instance>::kill();
-        OwnerStorage::<Instance, DefaultOwner>::mutate(|owner| {
-            *owner = target_new_owner;
-        });
-
-        log1(
-            handle.context().address,
-            SELECTOR_LOG_NEW_OWNER,
-            EvmDataWriter::new()
-                .write(Into::<H256>::into(target_new_owner))
-                .build(),
-        )
-        .record(handle)?;
-
-        Ok(())
-    }
-
-    #[precompile::public("totalSupply()")]
-    #[precompile::view]
-    fn total_supply(handle: &mut impl PrecompileHandle) -> EvmResult<U256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        Ok(pallet_balances::Pallet::<Runtime, Instance>::total_issuance().into())
-    }
-
-    #[precompile::public("balanceOf(address)")]
-    #[precompile::view]
-    fn balance_of(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        let owner: H160 = owner.into();
-        let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
-
-        Ok(pallet_balances::Pallet::<Runtime, Instance>::usable_balance(&owner).into())
-    }
-
-    #[precompile::public("allowance(address,address)")]
-    #[precompile::view]
-    fn allowance(
-        handle: &mut impl PrecompileHandle,
-        owner: Address,
-        spender: Address,
-    ) -> EvmResult<U256> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-
-        let owner: H160 = owner.into();
-        let spender: H160 = spender.into();
-
-        let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
-        let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
-
-        Ok(ApprovesStorage::<Runtime, Instance>::get(owner, spender)
-            .unwrap_or_default()
-            .into())
-    }
-
-    #[precompile::public("approve(address,uint256)")]
-    fn approve(
-        handle: &mut impl PrecompileHandle,
-        spender: Address,
-        value: U256,
-    ) -> EvmResult<bool> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-        handle.record_log_costs_manual(3, 32)?;
-
-        let spender: H160 = spender.into();
-
-        // Write into storage.
-        {
-            let caller: Runtime::AccountId =
-                Runtime::AddressMapping::into_account_id(handle.context().caller);
-            let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
-            // Amount saturate if too high.
-            let value = Self::u256_to_amount(value).unwrap_or_else(|_| Bounded::max_value());
-
-            ApprovesStorage::<Runtime, Instance>::insert(caller, spender, value);
-        }
-
-        log3(
-            handle.context().address,
-            SELECTOR_LOG_APPROVAL,
-            handle.context().caller,
-            spender,
-            EvmDataWriter::new().write(value).build(),
-        )
-        .record(handle)?;
-
-        // Build output.
-        Ok(true)
-    }
-
-    #[precompile::public("transfer(address,uint256)")]
-    fn transfer(handle: &mut impl PrecompileHandle, to: Address, value: U256) -> EvmResult<bool> {
-        handle.record_log_costs_manual(3, 32)?;
-
-        let to: H160 = to.into();
-
-        // Build call with origin.
-        {
-            let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-            let to = Runtime::AddressMapping::into_account_id(to);
-            let value = Self::u256_to_amount(value).in_field("value")?;
-
-            // Dispatch call (if enough gas).
-            RuntimeHelper::<Runtime>::try_dispatch(
-                handle,
-                Some(origin).into(),
-                pallet_balances::Call::<Runtime, Instance>::transfer {
-                    dest: Runtime::Lookup::unlookup(to),
-                    value: value,
-                },
-            )?;
-        }
-
-        log3(
-            handle.context().address,
-            SELECTOR_LOG_TRANSFER,
-            handle.context().caller,
-            to,
-            EvmDataWriter::new().write(value).build(),
-        )
-        .record(handle)?;
-
-        Ok(true)
-    }
-
-    #[precompile::public("transferFrom(address,address,uint256)")]
-    fn transfer_from(
-        handle: &mut impl PrecompileHandle,
-        from: Address,
-        to: Address,
-        value: U256,
-    ) -> EvmResult<bool> {
-        handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-        handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
-        handle.record_log_costs_manual(3, 32)?;
-
-        let from: H160 = from.into();
-        let to: H160 = to.into();
-
-        {
-            let caller: Runtime::AccountId =
-                Runtime::AddressMapping::into_account_id(handle.context().caller);
-            let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from);
-            let to: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to);
-            let value = Self::u256_to_amount(value).in_field("value")?;
-
-            // If caller is "from", it can spend as much as it wants.
-            if caller != from {
-                ApprovesStorage::<Runtime, Instance>::mutate(from.clone(), caller, |entry| {
-                    // Get current allowed value, exit if None.
-                    let allowed = entry.ok_or(revert("spender not allowed"))?;
-
-                    // Remove "value" from allowed, exit if underflow.
-                    let allowed = allowed
-                        .checked_sub(&value)
-                        .ok_or_else(|| revert("trying to spend more than allowed"))?;
-
-                    // Update allowed value.
-                    *entry = Some(allowed);
-
-                    EvmResult::Ok(())
-                })?;
-            }
-
-            // Build call with origin. Here origin is the "from"/owner field.
-            // Dispatch call (if enough gas).
-            RuntimeHelper::<Runtime>::try_dispatch(
-                handle,
-                Some(from).into(),
-                pallet_balances::Call::<Runtime, Instance>::transfer {
-                    dest: Runtime::Lookup::unlookup(to),
-                    value: value,
-                },
-            )?;
-        }
-
-        log3(
-            handle.context().address,
-            SELECTOR_LOG_TRANSFER,
-            from,
-            to,
-            EvmDataWriter::new().write(value).build(),
-        )
-        .record(handle)?;
-
-        Ok(true)
-    }
-
-    #[precompile::public("name()")]
-    #[precompile::view]
-    fn name(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
-        Ok(Metadata::name().into())
-    }
-
-    #[precompile::public("symbol()")]
-    #[precompile::view]
-    fn symbol(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
-        Ok(Metadata::symbol().into())
-    }
-
-    #[precompile::public("decimals()")]
-    #[precompile::view]
-    fn decimals(_handle: &mut impl PrecompileHandle) -> EvmResult<u8> {
-        Ok(Metadata::decimals())
-    }
-
-    #[precompile::public("deposit()")]
-    #[precompile::fallback]
-    #[precompile::payable]
-    fn deposit(handle: &mut impl PrecompileHandle) -> EvmResult {
-        // Deposit only makes sense for the native currency.
-        if !Metadata::is_native_currency() {
-            return Err(RevertReason::UnknownSelector.into());
-        }
-
-        let caller: Runtime::AccountId =
-            Runtime::AddressMapping::into_account_id(handle.context().caller);
-        let precompile = Runtime::AddressMapping::into_account_id(handle.context().address);
-        let amount = Self::u256_to_amount(handle.context().apparent_value)?;
-
-        if amount.into() == U256::from(0u32) {
-            return Err(revert("deposited amount must be non-zero"));
-        }
-
-        handle.record_log_costs_manual(2, 32)?;
-
-        // Send back funds received by the precompile.
-        RuntimeHelper::<Runtime>::try_dispatch(
-            handle,
-            Some(precompile).into(),
-            pallet_balances::Call::<Runtime, Instance>::transfer {
-                dest: Runtime::Lookup::unlookup(caller),
-                value: amount,
-            },
-        )?;
-
-        log2(
-            handle.context().address,
-            SELECTOR_LOG_DEPOSIT,
-            handle.context().caller,
-            EvmDataWriter::new()
-                .write(handle.context().apparent_value)
-                .build(),
-        )
-        .record(handle)?;
-
-        Ok(())
-    }
-
-    #[precompile::public("withdraw(uint256)")]
-    fn withdraw(handle: &mut impl PrecompileHandle, value: U256) -> EvmResult {
-        // Withdraw only makes sense for the native currency.
-        if !Metadata::is_native_currency() {
-            return Err(RevertReason::UnknownSelector.into());
-        }
-
-        handle.record_log_costs_manual(2, 32)?;
-
-        let account_amount: U256 = {
-            let owner: Runtime::AccountId =
-                Runtime::AddressMapping::into_account_id(handle.context().caller);
-            pallet_balances::Pallet::<Runtime, Instance>::usable_balance(&owner).into()
-        };
-
-        if value > account_amount {
-            return Err(revert("Trying to withdraw more than owned"));
-        }
-
-        log2(
-            handle.context().address,
-            SELECTOR_LOG_WITHDRAWAL,
-            handle.context().caller,
-            EvmDataWriter::new().write(value).build(),
-        )
-        .record(handle)?;
-
-        Ok(())
-    }
-
-    #[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
-    fn eip2612_permit(
-        handle: &mut impl PrecompileHandle,
-        owner: Address,
-        spender: Address,
-        value: U256,
-        deadline: U256,
-        v: u8,
-        r: H256,
-        s: H256,
-    ) -> EvmResult {
-        <Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::permit(
-            handle, owner, spender, value, deadline, v, r, s,
-        )
-    }
-
-    #[precompile::public("nonces(address)")]
-    #[precompile::view]
-    fn eip2612_nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
-        <Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::nonces(handle, owner)
-    }
-
-    #[precompile::public("DOMAIN_SEPARATOR()")]
-    #[precompile::view]
-    fn eip2612_domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-        <Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::domain_separator(handle)
-    }
-
-    fn u256_to_amount(value: U256) -> MayRevert<BalanceOf<Runtime, Instance>> {
-        value
-            .try_into()
-            .map_err(|_| RevertReason::value_is_too_large("balance type").into())
-    }
+	#[precompile::public("owner()")]
+	#[precompile::view]
+	fn owner(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		Ok(OwnerStorage::<Instance, DefaultOwner>::get().into())
+	}
+
+	#[precompile::public("pendingOwner()")]
+	#[precompile::view]
+	fn pending_owner(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		Ok(ClaimableOwnerStorage::<Instance>::get().into())
+	}
+
+	#[precompile::public("mintTo(address,uint256)")]
+	fn mint_to(handle: &mut impl PrecompileHandle, to: Address, amount: U256) -> EvmResult {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+
+		let sender = handle.context().caller;
+		let owner = OwnerStorage::<Instance, DefaultOwner>::get();
+
+		handle.record_log_costs_manual(3, 32)?;
+
+		let zero_address =
+			H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
+
+		if sender != owner {
+			Err(revert("sender is not owner"))
+		} else {
+			let target: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to.into());
+
+			pallet_balances::Pallet::<Runtime, Instance>::mint_into(
+				&target,
+				amount.saturated_into(),
+			)
+			.or_else(|_| Err(revert("mint operation overflow account balance")))?;
+
+			log3(
+				handle.context().address,
+				SELECTOR_LOG_TRANSFER,
+				zero_address,
+				Into::<H160>::into(to),
+				EvmDataWriter::new().write(amount).build(),
+			)
+			.record(handle)?;
+
+			Ok(())
+		}
+	}
+
+	#[precompile::public("burnFrom(address,uint256)")]
+	fn burn_from(handle: &mut impl PrecompileHandle, to: Address, amount: U256) -> EvmResult {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+
+		let sender = handle.context().caller;
+		let owner = OwnerStorage::<Instance, DefaultOwner>::get();
+
+		handle.record_log_costs_manual(3, 32)?;
+
+		let zero_address =
+			H160::from_str("0x0000000000000000000000000000000000000000").expect("invalid address");
+
+		if sender != owner {
+			Err(revert("sender is not owner"))
+		} else {
+			let target: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to.into());
+
+			pallet_balances::Pallet::<Runtime, Instance>::burn_from(
+				&target,
+				amount.saturated_into(),
+			)
+			.or_else(|_| return Err(revert("not enough balance to burn")))?;
+
+			log3(
+				handle.context().address,
+				SELECTOR_LOG_TRANSFER,
+				Into::<H160>::into(to),
+				zero_address,
+				EvmDataWriter::new().write(amount).build(),
+			)
+			.record(handle)?;
+
+			Ok(())
+		}
+	}
+
+	#[precompile::public("transferOwnership(address)")]
+	fn transfer_ownership(handle: &mut impl PrecompileHandle, new_owner: Address) -> EvmResult {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let sender = handle.context().caller;
+		let owner = OwnerStorage::<Instance, DefaultOwner>::get();
+
+		if sender != owner {
+			return Err(revert("sender is not owner"));
+		}
+
+		ClaimableOwnerStorage::<Instance>::mutate(move |claimable_owner| {
+			*claimable_owner = new_owner.into();
+		});
+
+		Ok(())
+	}
+
+	#[precompile::public("acceptOwnership()")]
+	fn claim_ownership(handle: &mut impl PrecompileHandle) -> EvmResult {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+
+		handle.record_log_costs_manual(1, 32)?;
+
+		let sender = handle.context().caller;
+
+		let target_new_owner = ClaimableOwnerStorage::<Instance>::get();
+
+		if target_new_owner != sender {
+			return Err(revert("target owner is not the claimer"));
+		}
+
+		ClaimableOwnerStorage::<Instance>::kill();
+		OwnerStorage::<Instance, DefaultOwner>::mutate(|owner| {
+			*owner = target_new_owner;
+		});
+
+		log1(
+			handle.context().address,
+			SELECTOR_LOG_NEW_OWNER,
+			EvmDataWriter::new()
+				.write(Into::<H256>::into(target_new_owner))
+				.build(),
+		)
+		.record(handle)?;
+
+		Ok(())
+	}
+
+	#[precompile::public("totalSupply()")]
+	#[precompile::view]
+	fn total_supply(handle: &mut impl PrecompileHandle) -> EvmResult<U256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		Ok(pallet_balances::Pallet::<Runtime, Instance>::total_issuance().into())
+	}
+
+	#[precompile::public("balanceOf(address)")]
+	#[precompile::view]
+	fn balance_of(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let owner: H160 = owner.into();
+		let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
+
+		Ok(pallet_balances::Pallet::<Runtime, Instance>::usable_balance(&owner).into())
+	}
+
+	#[precompile::public("allowance(address,address)")]
+	#[precompile::view]
+	fn allowance(
+		handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+	) -> EvmResult<U256> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let owner: H160 = owner.into();
+		let spender: H160 = spender.into();
+
+		let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);
+		let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
+
+		Ok(ApprovesStorage::<Runtime, Instance>::get(owner, spender)
+			.unwrap_or_default()
+			.into())
+	}
+
+	#[precompile::public("approve(address,uint256)")]
+	fn approve(
+		handle: &mut impl PrecompileHandle,
+		spender: Address,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+		handle.record_log_costs_manual(3, 32)?;
+
+		let spender: H160 = spender.into();
+
+		// Write into storage.
+		{
+			let caller: Runtime::AccountId =
+				Runtime::AddressMapping::into_account_id(handle.context().caller);
+			let spender: Runtime::AccountId = Runtime::AddressMapping::into_account_id(spender);
+			// Amount saturate if too high.
+			let value = Self::u256_to_amount(value).unwrap_or_else(|_| Bounded::max_value());
+
+			ApprovesStorage::<Runtime, Instance>::insert(caller, spender, value);
+		}
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			handle.context().caller,
+			spender,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
+
+		// Build output.
+		Ok(true)
+	}
+
+	#[precompile::public("transfer(address,uint256)")]
+	fn transfer(handle: &mut impl PrecompileHandle, to: Address, value: U256) -> EvmResult<bool> {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let to: H160 = to.into();
+
+		// Build call with origin.
+		{
+			let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
+			let to = Runtime::AddressMapping::into_account_id(to);
+			let value = Self::u256_to_amount(value).in_field("value")?;
+
+			// Dispatch call (if enough gas).
+			RuntimeHelper::<Runtime>::try_dispatch(
+				handle,
+				Some(origin).into(),
+				pallet_balances::Call::<Runtime, Instance>::transfer {
+					dest: Runtime::Lookup::unlookup(to),
+					value: value,
+				},
+			)?;
+		}
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			handle.context().caller,
+			to,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	#[precompile::public("transferFrom(address,address,uint256)")]
+	fn transfer_from(
+		handle: &mut impl PrecompileHandle,
+		from: Address,
+		to: Address,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+		handle.record_log_costs_manual(3, 32)?;
+
+		let from: H160 = from.into();
+		let to: H160 = to.into();
+
+		{
+			let caller: Runtime::AccountId =
+				Runtime::AddressMapping::into_account_id(handle.context().caller);
+			let from: Runtime::AccountId = Runtime::AddressMapping::into_account_id(from);
+			let to: Runtime::AccountId = Runtime::AddressMapping::into_account_id(to);
+			let value = Self::u256_to_amount(value).in_field("value")?;
+
+			// If caller is "from", it can spend as much as it wants.
+			if caller != from {
+				ApprovesStorage::<Runtime, Instance>::mutate(from.clone(), caller, |entry| {
+					// Get current allowed value, exit if None.
+					let allowed = entry.ok_or(revert("spender not allowed"))?;
+
+					// Remove "value" from allowed, exit if underflow.
+					let allowed = allowed
+						.checked_sub(&value)
+						.ok_or_else(|| revert("trying to spend more than allowed"))?;
+
+					// Update allowed value.
+					*entry = Some(allowed);
+
+					EvmResult::Ok(())
+				})?;
+			}
+
+			// Build call with origin. Here origin is the "from"/owner field.
+			// Dispatch call (if enough gas).
+			RuntimeHelper::<Runtime>::try_dispatch(
+				handle,
+				Some(from).into(),
+				pallet_balances::Call::<Runtime, Instance>::transfer {
+					dest: Runtime::Lookup::unlookup(to),
+					value: value,
+				},
+			)?;
+		}
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			from,
+			to,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	#[precompile::public("name()")]
+	#[precompile::view]
+	fn name(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
+		Ok(Metadata::name().into())
+	}
+
+	#[precompile::public("symbol()")]
+	#[precompile::view]
+	fn symbol(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
+		Ok(Metadata::symbol().into())
+	}
+
+	#[precompile::public("decimals()")]
+	#[precompile::view]
+	fn decimals(_handle: &mut impl PrecompileHandle) -> EvmResult<u8> {
+		Ok(Metadata::decimals())
+	}
+
+	#[precompile::public("deposit()")]
+	#[precompile::fallback]
+	#[precompile::payable]
+	fn deposit(handle: &mut impl PrecompileHandle) -> EvmResult {
+		// Deposit only makes sense for the native currency.
+		if !Metadata::is_native_currency() {
+			return Err(RevertReason::UnknownSelector.into());
+		}
+
+		let caller: Runtime::AccountId =
+			Runtime::AddressMapping::into_account_id(handle.context().caller);
+		let precompile = Runtime::AddressMapping::into_account_id(handle.context().address);
+		let amount = Self::u256_to_amount(handle.context().apparent_value)?;
+
+		if amount.into() == U256::from(0u32) {
+			return Err(revert("deposited amount must be non-zero"));
+		}
+
+		handle.record_log_costs_manual(2, 32)?;
+
+		// Send back funds received by the precompile.
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(precompile).into(),
+			pallet_balances::Call::<Runtime, Instance>::transfer {
+				dest: Runtime::Lookup::unlookup(caller),
+				value: amount,
+			},
+		)?;
+
+		log2(
+			handle.context().address,
+			SELECTOR_LOG_DEPOSIT,
+			handle.context().caller,
+			EvmDataWriter::new()
+				.write(handle.context().apparent_value)
+				.build(),
+		)
+		.record(handle)?;
+
+		Ok(())
+	}
+
+	#[precompile::public("withdraw(uint256)")]
+	fn withdraw(handle: &mut impl PrecompileHandle, value: U256) -> EvmResult {
+		// Withdraw only makes sense for the native currency.
+		if !Metadata::is_native_currency() {
+			return Err(RevertReason::UnknownSelector.into());
+		}
+
+		handle.record_log_costs_manual(2, 32)?;
+
+		let account_amount: U256 = {
+			let owner: Runtime::AccountId =
+				Runtime::AddressMapping::into_account_id(handle.context().caller);
+			pallet_balances::Pallet::<Runtime, Instance>::usable_balance(&owner).into()
+		};
+
+		if value > account_amount {
+			return Err(revert("Trying to withdraw more than owned"));
+		}
+
+		log2(
+			handle.context().address,
+			SELECTOR_LOG_WITHDRAWAL,
+			handle.context().caller,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
+
+		Ok(())
+	}
+
+	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
+	fn eip2612_permit(
+		handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+		value: U256,
+		deadline: U256,
+		v: u8,
+		r: H256,
+		s: H256,
+	) -> EvmResult {
+		<Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::permit(
+			handle, owner, spender, value, deadline, v, r, s,
+		)
+	}
+
+	#[precompile::public("nonces(address)")]
+	#[precompile::view]
+	fn eip2612_nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		<Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::nonces(handle, owner)
+	}
+
+	#[precompile::public("DOMAIN_SEPARATOR()")]
+	#[precompile::view]
+	fn eip2612_domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		<Eip2612<Runtime, Metadata, DefaultOwner, Instance>>::domain_separator(handle)
+	}
+
+	fn u256_to_amount(value: U256) -> MayRevert<BalanceOf<Runtime, Instance>> {
+		value
+			.try_into()
+			.map_err(|_| RevertReason::value_is_too_large("balance type").into())
+	}
 }

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -33,177 +33,177 @@ pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runt
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 
 parameter_types! {
-    pub const BlockHashCount: u32 = 250;
-    pub const SS58Prefix: u8 = 42;
+	pub const BlockHashCount: u32 = 250;
+	pub const SS58Prefix: u8 = 42;
 }
 
 impl frame_system::Config for Runtime {
-    type BaseCallFilter = Everything;
-    type DbWeight = ();
-    type RuntimeOrigin = RuntimeOrigin;
-    type Index = u64;
-    type BlockNumber = BlockNumber;
-    type RuntimeCall = RuntimeCall;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = AccountId;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
-    type RuntimeEvent = RuntimeEvent;
-    type BlockHashCount = BlockHashCount;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = pallet_balances::AccountData<Balance>;
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type SystemWeightInfo = ();
-    type BlockWeights = ();
-    type BlockLength = ();
-    type SS58Prefix = SS58Prefix;
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type BaseCallFilter = Everything;
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = u64;
+	type BlockNumber = BlockNumber;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {
-    pub const MinimumPeriod: u64 = 5;
+	pub const MinimumPeriod: u64 = 5;
 }
 
 impl pallet_timestamp::Config for Runtime {
-    type Moment = u64;
-    type OnTimestampSet = ();
-    type MinimumPeriod = MinimumPeriod;
-    type WeightInfo = ();
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u128 = 0;
+	pub const ExistentialDeposit: u128 = 0;
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxReserves = ();
-    type ReserveIdentifier = ();
-    type MaxLocks = ();
-    type Balance = Balance;
-    type RuntimeEvent = RuntimeEvent;
-    type DustRemoval = ();
-    type ExistentialDeposit = ExistentialDeposit;
-    type AccountStore = System;
-    type WeightInfo = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+	type MaxLocks = ();
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
-    pub DefaultOwner: H160 = H160::from_str("0xa58482131a8d67725e996af72D91A849AcC0F4A1").expect("invalid address");
+	pub DefaultOwner: H160 = H160::from_str("0xa58482131a8d67725e996af72D91A849AcC0F4A1").expect("invalid address");
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
-    R,
-    (PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata, DefaultOwner>>,),
+	R,
+	(PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata, DefaultOwner>>,),
 >;
 
 pub type PCall = Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata, DefaultOwner, ()>;
 
 parameter_types! {
-        pub BlockGasLimit: U256 = U256::max_value();
-        pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
-        pub const WeightPerGas: Weight = Weight::from_ref_time(1);
+		pub BlockGasLimit: U256 = U256::max_value();
+		pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
+		pub const WeightPerGas: Weight = Weight::from_ref_time(1);
 }
 
 impl pallet_evm::Config for Runtime {
-    type FeeCalculator = ();
-    type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
-    type WeightPerGas = WeightPerGas;
-    type CallOrigin = EnsureAddressRoot<AccountId>;
-    type WithdrawOrigin = EnsureAddressNever<AccountId>;
-    type AddressMapping = AccountId;
-    type Currency = Balances;
-    type RuntimeEvent = RuntimeEvent;
-    type Runner = pallet_evm::runner::stack::Runner<Self>;
-    type PrecompilesType = Precompiles<Self>;
-    type PrecompilesValue = PrecompilesValue;
-    type ChainId = ();
-    type OnChargeTransaction = ();
-    type BlockGasLimit = BlockGasLimit;
-    type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
-    type FindAuthor = ();
+	type FeeCalculator = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = AccountId;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Self>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = BlockGasLimit;
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
 }
 
 // Configure a mock runtime to test the pallet.
 construct_runtime!(
-    pub enum Runtime where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic,
-    {
-        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-        Evm: pallet_evm::{Pallet, Call, Storage, Event<T>},
-        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-    }
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Evm: pallet_evm::{Pallet, Call, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+	}
 );
 
 /// ERC20 metadata for the native token.
 pub struct NativeErc20Metadata;
 
 impl Erc20Metadata for NativeErc20Metadata {
-    /// Returns the name of the token.
-    fn name() -> &'static str {
-        "Mock token"
-    }
+	/// Returns the name of the token.
+	fn name() -> &'static str {
+		"Mock token"
+	}
 
-    /// Returns the symbol of the token.
-    fn symbol() -> &'static str {
-        "MOCK"
-    }
+	/// Returns the symbol of the token.
+	fn symbol() -> &'static str {
+		"MOCK"
+	}
 
-    /// Returns the decimals places of the token.
-    fn decimals() -> u8 {
-        18
-    }
+	/// Returns the decimals places of the token.
+	fn decimals() -> u8 {
+		18
+	}
 
-    /// Must return `true` only if it represents the main native currency of
-    /// the network. It must be the currency used in `pallet_evm`.
-    fn is_native_currency() -> bool {
-        true
-    }
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool {
+		true
+	}
 }
 
 pub(crate) struct ExtBuilder {
-    // endowed accounts with balances
-    balances: Vec<(AccountId, Balance)>,
+	// endowed accounts with balances
+	balances: Vec<(AccountId, Balance)>,
 }
 
 impl Default for ExtBuilder {
-    fn default() -> ExtBuilder {
-        ExtBuilder { balances: vec![] }
-    }
+	fn default() -> ExtBuilder {
+		ExtBuilder { balances: vec![] }
+	}
 }
 
 impl ExtBuilder {
-    pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
-        self.balances = balances;
-        self
-    }
+	pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
+		self.balances = balances;
+		self
+	}
 
-    pub(crate) fn build(self) -> sp_io::TestExternalities {
-        let mut t = frame_system::GenesisConfig::default()
-            .build_storage::<Runtime>()
-            .expect("Frame system builds valid default genesis config");
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.expect("Frame system builds valid default genesis config");
 
-        pallet_balances::GenesisConfig::<Runtime> {
-            balances: self.balances,
-        }
-        .assimilate_storage(&mut t)
-        .expect("Pallet balances storage can be assimilated");
+		pallet_balances::GenesisConfig::<Runtime> {
+			balances: self.balances,
+		}
+		.assimilate_storage(&mut t)
+		.expect("Pallet balances storage can be assimilated");
 
-        let mut ext = sp_io::TestExternalities::new(t);
-        ext.execute_with(|| System::set_block_number(1));
-        ext
-    }
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
 }
 
 pub(crate) fn events() -> Vec<RuntimeEvent> {
-    System::events()
-        .into_iter()
-        .map(|r| r.event)
-        .collect::<Vec<_>>()
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.collect::<Vec<_>>()
 }

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -29,1122 +29,1122 @@ use std::str::FromStr;
 
 // No test of invalid selectors since we have a fallback behavior (deposit).
 fn precompiles() -> Precompiles<Runtime> {
-    PrecompilesValue::get()
+	PrecompilesValue::get()
 }
 
 use crate::mock::DefaultOwner;
 
 #[test]
 fn selectors() {
-    assert!(PCall::balance_of_selectors().contains(&0x70a08231));
-    assert!(PCall::total_supply_selectors().contains(&0x18160ddd));
-    assert!(PCall::approve_selectors().contains(&0x095ea7b3));
-    assert!(PCall::allowance_selectors().contains(&0xdd62ed3e));
-    assert!(PCall::transfer_selectors().contains(&0xa9059cbb));
-    assert!(PCall::transfer_from_selectors().contains(&0x23b872dd));
-    assert!(PCall::name_selectors().contains(&0x06fdde03));
-    assert!(PCall::symbol_selectors().contains(&0x95d89b41));
-    assert!(PCall::deposit_selectors().contains(&0xd0e30db0));
-    assert!(PCall::withdraw_selectors().contains(&0x2e1a7d4d));
-    assert!(PCall::eip2612_nonces_selectors().contains(&0x7ecebe00));
-    assert!(PCall::eip2612_permit_selectors().contains(&0xd505accf));
-    assert!(PCall::eip2612_domain_separator_selectors().contains(&0x3644e515));
+	assert!(PCall::balance_of_selectors().contains(&0x70a08231));
+	assert!(PCall::total_supply_selectors().contains(&0x18160ddd));
+	assert!(PCall::approve_selectors().contains(&0x095ea7b3));
+	assert!(PCall::allowance_selectors().contains(&0xdd62ed3e));
+	assert!(PCall::transfer_selectors().contains(&0xa9059cbb));
+	assert!(PCall::transfer_from_selectors().contains(&0x23b872dd));
+	assert!(PCall::name_selectors().contains(&0x06fdde03));
+	assert!(PCall::symbol_selectors().contains(&0x95d89b41));
+	assert!(PCall::deposit_selectors().contains(&0xd0e30db0));
+	assert!(PCall::withdraw_selectors().contains(&0x2e1a7d4d));
+	assert!(PCall::eip2612_nonces_selectors().contains(&0x7ecebe00));
+	assert!(PCall::eip2612_permit_selectors().contains(&0xd505accf));
+	assert!(PCall::eip2612_domain_separator_selectors().contains(&0x3644e515));
 
-    assert_eq!(
-        crate::SELECTOR_LOG_TRANSFER,
-        &Keccak256::digest(b"Transfer(address,address,uint256)")[..]
-    );
+	assert_eq!(
+		crate::SELECTOR_LOG_TRANSFER,
+		&Keccak256::digest(b"Transfer(address,address,uint256)")[..]
+	);
 
-    assert_eq!(
-        crate::SELECTOR_LOG_APPROVAL,
-        &Keccak256::digest(b"Approval(address,address,uint256)")[..]
-    );
+	assert_eq!(
+		crate::SELECTOR_LOG_APPROVAL,
+		&Keccak256::digest(b"Approval(address,address,uint256)")[..]
+	);
 
-    assert_eq!(
-        crate::SELECTOR_LOG_DEPOSIT,
-        &Keccak256::digest(b"Deposit(address,uint256)")[..]
-    );
+	assert_eq!(
+		crate::SELECTOR_LOG_DEPOSIT,
+		&Keccak256::digest(b"Deposit(address,uint256)")[..]
+	);
 
-    assert_eq!(
-        crate::SELECTOR_LOG_WITHDRAWAL,
-        &Keccak256::digest(b"Withdrawal(address,uint256)")[..]
-    );
+	assert_eq!(
+		crate::SELECTOR_LOG_WITHDRAWAL,
+		&Keccak256::digest(b"Withdrawal(address,uint256)")[..]
+	);
 }
 
 #[test]
 fn modifiers() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            let mut tester =
-                PrecompilesModifierTester::new(precompiles(), CryptoAlith, Precompile1);
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			let mut tester =
+				PrecompilesModifierTester::new(precompiles(), CryptoAlith, Precompile1);
 
-            tester.test_view_modifier(PCall::balance_of_selectors());
-            tester.test_view_modifier(PCall::total_supply_selectors());
-            tester.test_default_modifier(PCall::approve_selectors());
-            tester.test_view_modifier(PCall::allowance_selectors());
-            tester.test_default_modifier(PCall::transfer_selectors());
-            tester.test_default_modifier(PCall::transfer_from_selectors());
-            tester.test_view_modifier(PCall::name_selectors());
-            tester.test_view_modifier(PCall::symbol_selectors());
-            tester.test_view_modifier(PCall::decimals_selectors());
-            tester.test_payable_modifier(PCall::deposit_selectors());
-            tester.test_default_modifier(PCall::withdraw_selectors());
-            tester.test_view_modifier(PCall::eip2612_nonces_selectors());
-            tester.test_default_modifier(PCall::eip2612_permit_selectors());
-            tester.test_view_modifier(PCall::eip2612_domain_separator_selectors());
-        });
+			tester.test_view_modifier(PCall::balance_of_selectors());
+			tester.test_view_modifier(PCall::total_supply_selectors());
+			tester.test_default_modifier(PCall::approve_selectors());
+			tester.test_view_modifier(PCall::allowance_selectors());
+			tester.test_default_modifier(PCall::transfer_selectors());
+			tester.test_default_modifier(PCall::transfer_from_selectors());
+			tester.test_view_modifier(PCall::name_selectors());
+			tester.test_view_modifier(PCall::symbol_selectors());
+			tester.test_view_modifier(PCall::decimals_selectors());
+			tester.test_payable_modifier(PCall::deposit_selectors());
+			tester.test_default_modifier(PCall::withdraw_selectors());
+			tester.test_view_modifier(PCall::eip2612_nonces_selectors());
+			tester.test_default_modifier(PCall::eip2612_permit_selectors());
+			tester.test_view_modifier(PCall::eip2612_domain_separator_selectors());
+		});
 }
 
 #[test]
 fn get_total_supply() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(CryptoAlith, Precompile1, PCall::total_supply {})
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(3500u64));
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(CryptoAlith, Precompile1, PCall::total_supply {})
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(3500u64));
+		});
 }
 
 #[test]
 fn get_balances_known_user() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1000u64));
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1000u64));
+		});
 }
 
 #[test]
 fn get_balances_unknown_user() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u64));
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u64));
+		});
 }
 
 #[test]
 fn approve() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::approve {
-                        spender: Address(Bob.into()),
-                        value: 500.into(),
-                    },
-                )
-                .expect_cost(1756)
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_APPROVAL,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(500)).build(),
-                ))
-                .execute_returns_encoded(true);
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::approve {
+						spender: Address(Bob.into()),
+						value: 500.into(),
+					},
+				)
+				.expect_cost(1756)
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_APPROVAL,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
+				.execute_returns_encoded(true);
+		});
 }
 
 #[test]
 fn approve_saturating() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::approve {
-                        spender: Address(Bob.into()),
-                        value: U256::MAX,
-                    },
-                )
-                .expect_cost(1756u64)
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_APPROVAL,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::MAX).build(),
-                ))
-                .execute_returns_encoded(true);
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::approve {
+						spender: Address(Bob.into()),
+						value: U256::MAX,
+					},
+				)
+				.expect_cost(1756u64)
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_APPROVAL,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::MAX).build(),
+				))
+				.execute_returns_encoded(true);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0)
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(u128::MAX));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0)
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(u128::MAX));
+		});
 }
 
 #[test]
 fn check_allowance_existing() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::approve {
-                        spender: Address(Bob.into()),
-                        value: 500.into(),
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::approve {
+						spender: Address(Bob.into()),
+						value: 500.into(),
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(500u64));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(500u64));
+		});
 }
 
 #[test]
 fn check_allowance_not_existing() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u64));
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u64));
+		});
 }
 
 #[test]
 fn transfer() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::transfer {
-                        to: Address(Bob.into()),
-                        value: 400.into(),
-                    },
-                )
-                .expect_cost(173812756) // 1 weight => 1 gas in mock
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_TRANSFER,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(400)).build(),
-                ))
-                .execute_returns_encoded(true);
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::transfer {
+						to: Address(Bob.into()),
+						value: 400.into(),
+					},
+				)
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_TRANSFER,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
+				.execute_returns_encoded(true);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(600));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(600));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(400));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(400));
+		});
 }
 
 #[test]
 fn transfer_not_enough_funds() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::transfer {
-                        to: Address(Bob.into()),
-                        value: 1400.into(),
-                    },
-                )
-                .execute_reverts(|output| {
-                    from_utf8(&output)
-                        .unwrap()
-                        .contains("Dispatched call failed with error: ")
-                        && from_utf8(&output).unwrap().contains("InsufficientBalance")
-                });
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::transfer {
+						to: Address(Bob.into()),
+						value: 1400.into(),
+					},
+				)
+				.execute_reverts(|output| {
+					from_utf8(&output)
+						.unwrap()
+						.contains("Dispatched call failed with error: ")
+						&& from_utf8(&output).unwrap().contains("InsufficientBalance")
+				});
+		});
 }
 
 #[test]
 fn transfer_from() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::approve {
-                        spender: Address(Bob.into()),
-                        value: 500.into(),
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::approve {
+						spender: Address(Bob.into()),
+						value: 500.into(),
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    Bob,
-                    Precompile1,
-                    PCall::transfer_from {
-                        from: Address(CryptoAlith.into()),
-                        to: Address(Bob.into()),
-                        value: 400.into(),
-                    },
-                )
-                .expect_cost(173812756) // 1 weight => 1 gas in mock
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_TRANSFER,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(400)).build(),
-                ))
-                .execute_returns_encoded(true);
+			precompiles()
+				.prepare_test(
+					Bob,
+					Precompile1,
+					PCall::transfer_from {
+						from: Address(CryptoAlith.into()),
+						to: Address(Bob.into()),
+						value: 400.into(),
+					},
+				)
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_TRANSFER,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
+				.execute_returns_encoded(true);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(600));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(600));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(400));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(400));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(100u64));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(100u64));
+		});
 }
 
 #[test]
 fn transfer_from_above_allowance() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::approve {
-                        spender: Address(Bob.into()),
-                        value: 300.into(),
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::approve {
+						spender: Address(Bob.into()),
+						value: 300.into(),
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    Bob, // Bob is the one sending transferFrom!
-                    Precompile1,
-                    PCall::transfer_from {
-                        from: Address(CryptoAlith.into()),
-                        to: Address(Bob.into()),
-                        value: 400.into(),
-                    },
-                )
-                .execute_reverts(|output| output == b"trying to spend more than allowed");
-        });
+			precompiles()
+				.prepare_test(
+					Bob, // Bob is the one sending transferFrom!
+					Precompile1,
+					PCall::transfer_from {
+						from: Address(CryptoAlith.into()),
+						to: Address(Bob.into()),
+						value: 400.into(),
+					},
+				)
+				.execute_reverts(|output| output == b"trying to spend more than allowed");
+		});
 }
 
 #[test]
 fn transfer_from_self() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    CryptoAlith, // CryptoAlith sending transferFrom herself, no need for allowance.
-                    Precompile1,
-                    PCall::transfer_from {
-                        from: Address(CryptoAlith.into()),
-                        to: Address(Bob.into()),
-                        value: 400.into(),
-                    },
-                )
-                .expect_cost(173812756) // 1 weight => 1 gas in mock
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_TRANSFER,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(400)).build(),
-                ))
-                .execute_returns_encoded(true);
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					CryptoAlith, // CryptoAlith sending transferFrom herself, no need for allowance.
+					Precompile1,
+					PCall::transfer_from {
+						from: Address(CryptoAlith.into()),
+						to: Address(Bob.into()),
+						value: 400.into(),
+					},
+				)
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_TRANSFER,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
+				.execute_returns_encoded(true);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(600));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(600));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(400));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(400));
+		});
 }
 
 #[test]
 fn get_metadata_name() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(CryptoAlith, Precompile1, PCall::name {})
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns(
-                    EvmDataWriter::new()
-                        .write::<UnboundedBytes>("Mock token".into())
-                        .build(),
-                );
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(CryptoAlith, Precompile1, PCall::name {})
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns(
+					EvmDataWriter::new()
+						.write::<UnboundedBytes>("Mock token".into())
+						.build(),
+				);
+		});
 }
 
 #[test]
 fn get_metadata_symbol() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(CryptoAlith, Precompile1, PCall::symbol {})
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns(
-                    EvmDataWriter::new()
-                        .write::<UnboundedBytes>("MOCK".into())
-                        .build(),
-                );
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(CryptoAlith, Precompile1, PCall::symbol {})
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns(
+					EvmDataWriter::new()
+						.write::<UnboundedBytes>("MOCK".into())
+						.build(),
+				);
+		});
 }
 
 #[test]
 fn get_metadata_decimals() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
-        .build()
-        .execute_with(|| {
-            precompiles()
-                .prepare_test(CryptoAlith, Precompile1, PCall::decimals {})
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(18u8);
-        });
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(CryptoAlith, Precompile1, PCall::decimals {})
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(18u8);
+		});
 }
 
 fn deposit(data: Vec<u8>) {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            // Check precompile balance is 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			// Check precompile balance is 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Deposit
-            // We need to call using EVM pallet so we can check the EVM correctly sends the amount
-            // to the precompile.
-            Evm::call(
-                RuntimeOrigin::root(),
-                CryptoAlith.into(),
-                Precompile1.into(),
-                data,
-                From::from(500), // amount sent
-                u64::MAX,        // gas limit
-                0u32.into(),     // gas price
-                None,            // max priority
-                None,            // nonce
-                vec![],          // access list
-            )
-            .expect("it works");
+			// Deposit
+			// We need to call using EVM pallet so we can check the EVM correctly sends the amount
+			// to the precompile.
+			Evm::call(
+				RuntimeOrigin::root(),
+				CryptoAlith.into(),
+				Precompile1.into(),
+				data,
+				From::from(500), // amount sent
+				u64::MAX,        // gas limit
+				0u32.into(),     // gas price
+				None,            // max priority
+				None,            // nonce
+				vec![],          // access list
+			)
+			.expect("it works");
 
-            assert_eq!(
-                events(),
-                vec![
-                    RuntimeEvent::System(frame_system::Event::NewAccount {
-                        account: Precompile1.into()
-                    }),
-                    RuntimeEvent::Balances(pallet_balances::Event::Endowed {
-                        account: Precompile1.into(),
-                        free_balance: 500
-                    }),
-                    // EVM make a transfer because some value is provided.
-                    RuntimeEvent::Balances(pallet_balances::Event::Transfer {
-                        from: CryptoAlith.into(),
-                        to: Precompile1.into(),
-                        amount: 500
-                    }),
-                    // Precompile1 send it back since deposit should be a no-op.
-                    RuntimeEvent::Balances(pallet_balances::Event::Transfer {
-                        from: Precompile1.into(),
-                        to: CryptoAlith.into(),
-                        amount: 500
-                    }),
-                    // Log is correctly emited.
-                    RuntimeEvent::Evm(pallet_evm::Event::Log {
-                        log: log2(
-                            Precompile1,
-                            SELECTOR_LOG_DEPOSIT,
-                            CryptoAlith,
-                            EvmDataWriter::new().write(U256::from(500)).build(),
-                        )
-                    }),
-                    RuntimeEvent::Evm(pallet_evm::Event::Executed {
-                        address: Precompile1.into()
-                    }),
-                ]
-            );
+			assert_eq!(
+				events(),
+				vec![
+					RuntimeEvent::System(frame_system::Event::NewAccount {
+						account: Precompile1.into()
+					}),
+					RuntimeEvent::Balances(pallet_balances::Event::Endowed {
+						account: Precompile1.into(),
+						free_balance: 500
+					}),
+					// EVM make a transfer because some value is provided.
+					RuntimeEvent::Balances(pallet_balances::Event::Transfer {
+						from: CryptoAlith.into(),
+						to: Precompile1.into(),
+						amount: 500
+					}),
+					// Precompile1 send it back since deposit should be a no-op.
+					RuntimeEvent::Balances(pallet_balances::Event::Transfer {
+						from: Precompile1.into(),
+						to: CryptoAlith.into(),
+						amount: 500
+					}),
+					// Log is correctly emited.
+					RuntimeEvent::Evm(pallet_evm::Event::Log {
+						log: log2(
+							Precompile1,
+							SELECTOR_LOG_DEPOSIT,
+							CryptoAlith,
+							EvmDataWriter::new().write(U256::from(500)).build(),
+						)
+					}),
+					RuntimeEvent::Evm(pallet_evm::Event::Executed {
+						address: Precompile1.into()
+					}),
+				]
+			);
 
-            // Check precompile balance is still 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+			// Check precompile balance is still 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Check CryptoAlith balance is still 1000.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1000));
-        });
+			// Check CryptoAlith balance is still 1000.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1000));
+		});
 }
 
 #[test]
 fn deposit_function() {
-    deposit(PCall::deposit {}.into())
+	deposit(PCall::deposit {}.into())
 }
 
 #[test]
 fn deposit_fallback() {
-    deposit(EvmDataWriter::new_with_selector(0x01234567u32).build())
+	deposit(EvmDataWriter::new_with_selector(0x01234567u32).build())
 }
 
 #[test]
 fn deposit_receive() {
-    deposit(vec![])
+	deposit(vec![])
 }
 
 #[test]
 fn deposit_zero() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            // Check precompile balance is 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			// Check precompile balance is 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Deposit
-            // We need to call using EVM pallet so we can check the EVM correctly sends the amount
-            // to the precompile.
-            Evm::call(
-                RuntimeOrigin::root(),
-                CryptoAlith.into(),
-                Precompile1.into(),
-                PCall::deposit {}.into(),
-                From::from(0), // amount sent
-                u64::MAX,      // gas limit
-                0u32.into(),   // gas price
-                None,          // max priority
-                None,          // nonce
-                vec![],        // access list
-            )
-            .expect("it works");
+			// Deposit
+			// We need to call using EVM pallet so we can check the EVM correctly sends the amount
+			// to the precompile.
+			Evm::call(
+				RuntimeOrigin::root(),
+				CryptoAlith.into(),
+				Precompile1.into(),
+				PCall::deposit {}.into(),
+				From::from(0), // amount sent
+				u64::MAX,      // gas limit
+				0u32.into(),   // gas price
+				None,          // max priority
+				None,          // nonce
+				vec![],        // access list
+			)
+			.expect("it works");
 
-            assert_eq!(
-                events(),
-                vec![RuntimeEvent::Evm(pallet_evm::Event::ExecutedFailed {
-                    address: Precompile1.into()
-                }),]
-            );
+			assert_eq!(
+				events(),
+				vec![RuntimeEvent::Evm(pallet_evm::Event::ExecutedFailed {
+					address: Precompile1.into()
+				}),]
+			);
 
-            // Check precompile balance is still 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+			// Check precompile balance is still 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Check CryptoAlith balance is still 1000.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1000));
-        });
+			// Check CryptoAlith balance is still 1000.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1000));
+		});
 }
 
 #[test]
 fn withdraw() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            // Check precompile balance is 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			// Check precompile balance is 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Withdraw
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::withdraw { value: 500.into() },
-                )
-                .expect_cost(1381)
-                .expect_log(log2(
-                    Precompile1,
-                    SELECTOR_LOG_WITHDRAWAL,
-                    CryptoAlith,
-                    EvmDataWriter::new().write(U256::from(500)).build(),
-                ))
-                .execute_returns(vec![]);
+			// Withdraw
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::withdraw { value: 500.into() },
+				)
+				.expect_cost(1381)
+				.expect_log(log2(
+					Precompile1,
+					SELECTOR_LOG_WITHDRAWAL,
+					CryptoAlith,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
+				.execute_returns(vec![]);
 
-            // Check CryptoAlith balance is still 1000.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1000));
-        });
+			// Check CryptoAlith balance is still 1000.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1000));
+		});
 }
 
 #[test]
 fn withdraw_more_than_owned() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            // Check precompile balance is 0.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(Precompile1.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0));
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			// Check precompile balance is 0.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(Precompile1.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0));
 
-            // Withdraw
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::withdraw { value: 1001.into() },
-                )
-                .execute_reverts(|output| output == b"Trying to withdraw more than owned");
+			// Withdraw
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::withdraw { value: 1001.into() },
+				)
+				.execute_reverts(|output| output == b"Trying to withdraw more than owned");
 
-            // Check CryptoAlith balance is still 1000.
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1000));
-        });
+			// Check CryptoAlith balance is still 1000.
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::balance_of {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1000));
+		});
 }
 
 #[test]
 fn permit_valid() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            let owner: H160 = CryptoAlith.into();
-            let spender: H160 = Bob.into();
-            let value: U256 = 500u16.into();
-            let deadline: U256 = 0u8.into(); // todo: proper timestamp
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			let owner: H160 = CryptoAlith.into();
+			let spender: H160 = Bob.into();
+			let value: U256 = 500u16.into();
+			let deadline: U256 = 0u8.into(); // todo: proper timestamp
 
-            let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
-                Precompile1.into(),
-                owner,
-                spender,
-                value,
-                0u8.into(), // nonce
-                deadline,
-            );
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
+				Precompile1.into(),
+				owner,
+				spender,
+				value,
+				0u8.into(), // nonce
+				deadline,
+			);
 
-            let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
-            let message = Message::parse(&permit);
-            let (rs, v) = sign(&message, &secret_key);
+			let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
+			let message = Message::parse(&permit);
+			let (rs, v) = sign(&message, &secret_key);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
 
-            precompiles()
-                .prepare_test(
-                    Charlie, // can be anyone
-                    Precompile1,
-                    PCall::eip2612_permit {
-                        owner: Address(owner),
-                        spender: Address(spender),
-                        value,
-                        deadline,
-                        v: v.serialize(),
-                        r: rs.r.b32().into(),
-                        s: rs.s.b32().into(),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_APPROVAL,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(value)).build(),
-                ))
-                .execute_returns(vec![]);
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone
+					Precompile1,
+					PCall::eip2612_permit {
+						owner: Address(owner),
+						spender: Address(spender),
+						value,
+						deadline,
+						v: v.serialize(),
+						r: rs.r.b32().into(),
+						s: rs.s.b32().into(),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_APPROVAL,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(value)).build(),
+				))
+				.execute_returns(vec![]);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(500u16));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(500u16));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(1u8));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(1u8));
+		});
 }
 
 #[test]
 fn permit_invalid_nonce() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            let owner: H160 = CryptoAlith.into();
-            let spender: H160 = Bob.into();
-            let value: U256 = 500u16.into();
-            let deadline: U256 = 0u8.into();
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			let owner: H160 = CryptoAlith.into();
+			let spender: H160 = Bob.into();
+			let value: U256 = 500u16.into();
+			let deadline: U256 = 0u8.into();
 
-            let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
-                Precompile1.into(),
-                owner,
-                spender,
-                value,
-                1u8.into(), // nonce
-                deadline,
-            );
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
+				Precompile1.into(),
+				owner,
+				spender,
+				value,
+				1u8.into(), // nonce
+				deadline,
+			);
 
-            let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
-            let message = Message::parse(&permit);
-            let (rs, v) = sign(&message, &secret_key);
+			let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
+			let message = Message::parse(&permit);
+			let (rs, v) = sign(&message, &secret_key);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
 
-            precompiles()
-                .prepare_test(
-                    Charlie, // can be anyone
-                    Precompile1,
-                    PCall::eip2612_permit {
-                        owner: Address(owner),
-                        spender: Address(spender),
-                        value,
-                        deadline,
-                        v: v.serialize(),
-                        r: rs.r.b32().into(),
-                        s: rs.s.b32().into(),
-                    },
-                )
-                .execute_reverts(|output| output == b"Invalid permit");
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone
+					Precompile1,
+					PCall::eip2612_permit {
+						owner: Address(owner),
+						spender: Address(spender),
+						value,
+						deadline,
+						v: v.serialize(),
+						r: rs.r.b32().into(),
+						s: rs.s.b32().into(),
+					},
+				)
+				.execute_reverts(|output| output == b"Invalid permit");
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u16));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u16));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
+		});
 }
 
 #[test]
 fn permit_invalid_signature() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            let owner: H160 = CryptoAlith.into();
-            let spender: H160 = Bob.into();
-            let value: U256 = 500u16.into();
-            let deadline: U256 = 0u8.into();
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			let owner: H160 = CryptoAlith.into();
+			let spender: H160 = Bob.into();
+			let value: U256 = 500u16.into();
+			let deadline: U256 = 0u8.into();
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
 
-            precompiles()
-                .prepare_test(
-                    Charlie, // can be anyone
-                    Precompile1,
-                    PCall::eip2612_permit {
-                        owner: Address(owner),
-                        spender: Address(spender),
-                        value,
-                        deadline,
-                        v: 0,
-                        r: H256::repeat_byte(0x11),
-                        s: H256::repeat_byte(0x11),
-                    },
-                )
-                .execute_reverts(|output| output == b"Invalid permit");
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone
+					Precompile1,
+					PCall::eip2612_permit {
+						owner: Address(owner),
+						spender: Address(spender),
+						value,
+						deadline,
+						v: 0,
+						r: H256::repeat_byte(0x11),
+						s: H256::repeat_byte(0x11),
+					},
+				)
+				.execute_reverts(|output| output == b"Invalid permit");
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u16));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u16));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
+		});
 }
 
 #[test]
 fn permit_invalid_deadline() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            pallet_timestamp::Pallet::<Runtime>::set_timestamp(10_000);
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_timestamp::Pallet::<Runtime>::set_timestamp(10_000);
 
-            let owner: H160 = CryptoAlith.into();
-            let spender: H160 = Bob.into();
-            let value: U256 = 500u16.into();
-            let deadline: U256 = 5u8.into(); // deadline < timestamp => expired
+			let owner: H160 = CryptoAlith.into();
+			let spender: H160 = Bob.into();
+			let value: U256 = 500u16.into();
+			let deadline: U256 = 5u8.into(); // deadline < timestamp => expired
 
-            let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
-                Precompile1.into(),
-                owner,
-                spender,
-                value,
-                0u8.into(), // nonce
-                deadline,
-            );
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, DefaultOwner>::generate_permit(
+				Precompile1.into(),
+				owner,
+				spender,
+				value,
+				0u8.into(), // nonce
+				deadline,
+			);
 
-            let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
-            let message = Message::parse(&permit);
-            let (rs, v) = sign(&message, &secret_key);
+			let secret_key = SecretKey::parse(&alith_secret_key()).unwrap();
+			let message = Message::parse(&permit);
+			let (rs, v) = sign(&message, &secret_key);
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
 
-            precompiles()
-                .prepare_test(
-                    Charlie, // can be anyone
-                    Precompile1,
-                    PCall::eip2612_permit {
-                        owner: Address(owner),
-                        spender: Address(spender),
-                        value,
-                        deadline,
-                        v: v.serialize(),
-                        r: rs.r.b32().into(),
-                        s: rs.s.b32().into(),
-                    },
-                )
-                .execute_reverts(|output| output == b"Permit expired");
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone
+					Precompile1,
+					PCall::eip2612_permit {
+						owner: Address(owner),
+						spender: Address(spender),
+						value,
+						deadline,
+						v: v.serialize(),
+						r: rs.r.b32().into(),
+						s: rs.s.b32().into(),
+					},
+				)
+				.execute_reverts(|output| output == b"Permit expired");
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::allowance {
-                        owner: Address(CryptoAlith.into()),
-                        spender: Address(Bob.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u16));
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::allowance {
+						owner: Address(CryptoAlith.into()),
+						spender: Address(Bob.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u16));
 
-            precompiles()
-                .prepare_test(
-                    CryptoAlith,
-                    Precompile1,
-                    PCall::eip2612_nonces {
-                        owner: Address(CryptoAlith.into()),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_no_logs()
-                .execute_returns_encoded(U256::from(0u8));
-        });
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::eip2612_nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(U256::from(0u8));
+		});
 }
 
 // This test checks the validity of a metamask signed message against the permit precompile
@@ -1164,71 +1164,71 @@ const spender = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 const from = accounts[0];
 
 const createPermitMessageData = function () {
-    const message = {
-    owner: from,
-    spender: spender,
-    value: value,
-    nonce: nonce,
-    deadline: deadline,
-    };
+	const message = {
+	owner: from,
+	spender: spender,
+	value: value,
+	nonce: nonce,
+	deadline: deadline,
+	};
 
-    const typedData = JSON.stringify({
-    types: {
-        EIP712Domain: [
-        {
-            name: "name",
-            type: "string",
-        },
-        {
-            name: "version",
-            type: "string",
-        },
-        {
-            name: "chainId",
-            type: "uint256",
-        },
-        {
-            name: "verifyingContract",
-            type: "address",
-        },
-        ],
-        Permit: [
-        {
-            name: "owner",
-            type: "address",
-        },
-        {
-            name: "spender",
-            type: "address",
-        },
-        {
-            name: "value",
-            type: "uint256",
-        },
-        {
-            name: "nonce",
-            type: "uint256",
-        },
-        {
-            name: "deadline",
-            type: "uint256",
-        },
-        ],
-    },
-    primaryType: "Permit",
-    domain: {
-        name: "Mock token",
-        version: "1",
-        chainId: 0,
-        verifyingContract: "0x0000000000000000000000000000000000000001",
-    },
-    message: message,
-    });
+	const typedData = JSON.stringify({
+	types: {
+		EIP712Domain: [
+		{
+			name: "name",
+			type: "string",
+		},
+		{
+			name: "version",
+			type: "string",
+		},
+		{
+			name: "chainId",
+			type: "uint256",
+		},
+		{
+			name: "verifyingContract",
+			type: "address",
+		},
+		],
+		Permit: [
+		{
+			name: "owner",
+			type: "address",
+		},
+		{
+			name: "spender",
+			type: "address",
+		},
+		{
+			name: "value",
+			type: "uint256",
+		},
+		{
+			name: "nonce",
+			type: "uint256",
+		},
+		{
+			name: "deadline",
+			type: "uint256",
+		},
+		],
+	},
+	primaryType: "Permit",
+	domain: {
+		name: "Mock token",
+		version: "1",
+		chainId: 0,
+		verifyingContract: "0x0000000000000000000000000000000000000001",
+	},
+	message: message,
+	});
 
-    return {
-        typedData,
-        message,
-    };
+	return {
+		typedData,
+		message,
+	};
 };
 
 const method = "eth_signTypedData_v4"
@@ -1236,473 +1236,473 @@ const messageData = createPermitMessageData();
 const params = [from, messageData.typedData];
 
 web3.currentProvider.sendAsync(
-    {
-        method,
-        params,
-        from,
-    },
-    function (err, result) {
-        if (err) return console.dir(err);
-        if (result.error) {
-            alert(result.error.message);
-        }
-        if (result.error) return console.error('ERROR', result);
-        console.log('TYPED SIGNED:' + JSON.stringify(result.result));
+	{
+		method,
+		params,
+		from,
+	},
+	function (err, result) {
+		if (err) return console.dir(err);
+		if (result.error) {
+			alert(result.error.message);
+		}
+		if (result.error) return console.error('ERROR', result);
+		console.log('TYPED SIGNED:' + JSON.stringify(result.result));
 
-        const recovered = sigUtil.recoverTypedSignature_v4({
-            data: JSON.parse(msgParams),
-            sig: result.result,
-        });
+		const recovered = sigUtil.recoverTypedSignature_v4({
+			data: JSON.parse(msgParams),
+			sig: result.result,
+		});
 
-        if (
-            ethUtil.toChecksumAddress(recovered) === ethUtil.toChecksumAddress(from)
-        ) {
-            alert('Successfully recovered signer as ' + from);
-        } else {
-            alert(
-                'Failed to verify signer when comparing ' + result + ' to ' + from
-            );
-        }
-    }
+		if (
+			ethUtil.toChecksumAddress(recovered) === ethUtil.toChecksumAddress(from)
+		) {
+			alert('Successfully recovered signer as ' + from);
+		} else {
+			alert(
+				'Failed to verify signer when comparing ' + result + ' to ' + from
+			);
+		}
+	}
 );
 */
 
 #[test]
 fn permit_valid_with_metamask_signed_data() {
-    ExtBuilder::default()
-        .with_balances(vec![(CryptoAlith.into(), 1000)])
-        .build()
-        .execute_with(|| {
-            let owner: H160 = CryptoAlith.into();
-            let spender: H160 = Bob.into();
-            let value: U256 = 1000u16.into();
-            let deadline: U256 = 1u16.into(); // todo: proper timestamp
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			let owner: H160 = CryptoAlith.into();
+			let spender: H160 = Bob.into();
+			let value: U256 = 1000u16.into();
+			let deadline: U256 = 1u16.into(); // todo: proper timestamp
 
-            let rsv = hex_literal::hex!(
-                "612960858951e133d05483804be5456a030be4ce6c000a855d865c0be75a8fc11d89ca96d5a153e8c
+			let rsv = hex_literal::hex!(
+				"612960858951e133d05483804be5456a030be4ce6c000a855d865c0be75a8fc11d89ca96d5a153e8c
 				7155ab1147f0f6d3326388b8d866c2406ce34567b7501a01b"
-            )
-            .as_slice();
-            let (r, sv) = rsv.split_at(32);
-            let (s, v) = sv.split_at(32);
-            let v_real = v[0];
-            let r_real: [u8; 32] = r.try_into().unwrap();
-            let s_real: [u8; 32] = s.try_into().unwrap();
+			)
+			.as_slice();
+			let (r, sv) = rsv.split_at(32);
+			let (s, v) = sv.split_at(32);
+			let v_real = v[0];
+			let r_real: [u8; 32] = r.try_into().unwrap();
+			let s_real: [u8; 32] = s.try_into().unwrap();
 
-            precompiles()
-                .prepare_test(
-                    Charlie, // can be anyone,
-                    Precompile1,
-                    PCall::eip2612_permit {
-                        owner: Address(owner),
-                        spender: Address(spender),
-                        value,
-                        deadline,
-                        v: v_real,
-                        r: r_real.into(),
-                        s: s_real.into(),
-                    },
-                )
-                .expect_cost(0) // TODO: Test db read/write costs
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_APPROVAL,
-                    CryptoAlith,
-                    Bob,
-                    EvmDataWriter::new().write(U256::from(1000)).build(),
-                ))
-                .execute_returns(vec![]);
-        });
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone,
+					Precompile1,
+					PCall::eip2612_permit {
+						owner: Address(owner),
+						spender: Address(spender),
+						value,
+						deadline,
+						v: v_real,
+						r: r_real.into(),
+						s: s_real.into(),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_APPROVAL,
+					CryptoAlith,
+					Bob,
+					EvmDataWriter::new().write(U256::from(1000)).build(),
+				))
+				.execute_returns(vec![]);
+		});
 }
 
 #[test]
 fn test_solidity_interface_has_all_function_selectors_documented_and_implemented() {
-    for file in ["ERC20.sol", "Permit.sol", "Ownable2Step.sol"] {
-        for solidity_fn in solidity::get_selectors(file) {
-            assert_eq!(
-                solidity_fn.compute_selector_hex(),
-                solidity_fn.docs_selector,
-                "documented selector for '{}' did not match for file '{}'",
-                solidity_fn.signature(),
-                file,
-            );
+	for file in ["ERC20.sol", "Permit.sol", "Ownable2Step.sol"] {
+		for solidity_fn in solidity::get_selectors(file) {
+			assert_eq!(
+				solidity_fn.compute_selector_hex(),
+				solidity_fn.docs_selector,
+				"documented selector for '{}' did not match for file '{}'",
+				solidity_fn.signature(),
+				file,
+			);
 
-            let selector = solidity_fn.compute_selector();
-            if !PCall::supports_selector(selector) {
-                panic!(
-                    "failed decoding selector 0x{:x} => '{}' as Action for file '{}'",
-                    selector,
-                    solidity_fn.signature(),
-                    file,
-                )
-            }
-        }
-    }
+			let selector = solidity_fn.compute_selector();
+			if !PCall::supports_selector(selector) {
+				panic!(
+					"failed decoding selector 0x{:x} => '{}' as Action for file '{}'",
+					selector,
+					solidity_fn.signature(),
+					file,
+				)
+			}
+		}
+	}
 }
 
 #[test]
 fn owner_correctly_init() {
-    ExtBuilder::default().build().execute_with(|| {
-        precompiles()
-            .prepare_test(DefaultOwner::get(), Precompile1, PCall::owner {})
-            .execute_returns_encoded(Into::<H256>::into(DefaultOwner::get()));
-    })
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(DefaultOwner::get(), Precompile1, PCall::owner {})
+			.execute_returns_encoded(Into::<H256>::into(DefaultOwner::get()));
+	})
 }
 
 parameter_types! {
-    pub UnpermissionedAccount:H160 = H160::from_str("0x1000000000000000000000000000000000000000").expect("invalid address");
-    pub UnpermissionedAccount2:H160 = H160::from_str("0x2000000000000000000000000000000000000000").expect("invalid address");
+	pub UnpermissionedAccount:H160 = H160::from_str("0x1000000000000000000000000000000000000000").expect("invalid address");
+	pub UnpermissionedAccount2:H160 = H160::from_str("0x2000000000000000000000000000000000000000").expect("invalid address");
 }
 
 #[test]
 
 fn transfer_ownership_set_target_if_owner_twice() {
-    ExtBuilder::default().build().execute_with(|| {
-        let new_owner = UnpermissionedAccount::get();
-        let other_owner = UnpermissionedAccount2::get();
+	ExtBuilder::default().build().execute_with(|| {
+		let new_owner = UnpermissionedAccount::get();
+		let other_owner = UnpermissionedAccount2::get();
 
-        precompiles()
-            .prepare_test(
-                DefaultOwner::get(),
-                Precompile1,
-                PCall::transfer_ownership {
-                    new_owner: precompile_utils::data::Address(new_owner),
-                },
-            )
-            .execute_some();
+		precompiles()
+			.prepare_test(
+				DefaultOwner::get(),
+				Precompile1,
+				PCall::transfer_ownership {
+					new_owner: precompile_utils::data::Address(new_owner),
+				},
+			)
+			.execute_some();
 
-        precompiles()
-            .prepare_test(DefaultOwner::get(), Precompile1, PCall::pending_owner {})
-            .execute_returns_encoded(Into::<H256>::into(new_owner));
+		precompiles()
+			.prepare_test(DefaultOwner::get(), Precompile1, PCall::pending_owner {})
+			.execute_returns_encoded(Into::<H256>::into(new_owner));
 
-        precompiles()
-            .prepare_test(
-                DefaultOwner::get(),
-                Precompile1,
-                PCall::transfer_ownership {
-                    new_owner: precompile_utils::data::Address(other_owner),
-                },
-            )
-            .execute_some();
+		precompiles()
+			.prepare_test(
+				DefaultOwner::get(),
+				Precompile1,
+				PCall::transfer_ownership {
+					new_owner: precompile_utils::data::Address(other_owner),
+				},
+			)
+			.execute_some();
 
-        precompiles()
-            .prepare_test(DefaultOwner::get(), Precompile1, PCall::pending_owner {})
-            .execute_returns_encoded(Into::<H256>::into(other_owner));
-    })
+		precompiles()
+			.prepare_test(DefaultOwner::get(), Precompile1, PCall::pending_owner {})
+			.execute_returns_encoded(Into::<H256>::into(other_owner));
+	})
 }
 
 #[test]
 fn fail_transfer_ownership_if_not_owner() {
-    ExtBuilder::default().build().execute_with(|| {
-        let new_owner = UnpermissionedAccount::get();
+	ExtBuilder::default().build().execute_with(|| {
+		let new_owner = UnpermissionedAccount::get();
 
-        precompiles()
-            .prepare_test(
-                new_owner,
-                Precompile1,
-                PCall::transfer_ownership {
-                    new_owner: precompile_utils::data::Address(new_owner),
-                },
-            )
-            .execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
-    })
+		precompiles()
+			.prepare_test(
+				new_owner,
+				Precompile1,
+				PCall::transfer_ownership {
+					new_owner: precompile_utils::data::Address(new_owner),
+				},
+			)
+			.execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
+	})
 }
 
 #[test]
 fn fail_claim_ownership_if_not_claimable() {
-    let new_owner = UnpermissionedAccount::get();
-    ExtBuilder::default().build().execute_with(|| {
-        precompiles()
-            .prepare_test(new_owner, Precompile1, PCall::claim_ownership {})
-            .execute_reverts(|x| x.eq_ignore_ascii_case(b"target owner is not the claimer"))
-    });
+	let new_owner = UnpermissionedAccount::get();
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(new_owner, Precompile1, PCall::claim_ownership {})
+			.execute_reverts(|x| x.eq_ignore_ascii_case(b"target owner is not the claimer"))
+	});
 }
 
 #[test]
 fn claim_ownership_if_claimable() {
-    let owner = DefaultOwner::get();
-    let new_owner = UnpermissionedAccount::get();
-    ExtBuilder::default().build().execute_with(|| {
-        precompiles()
-            .prepare_test(
-                owner,
-                Precompile1,
-                PCall::transfer_ownership {
-                    new_owner: precompile_utils::data::Address(new_owner),
-                },
-            )
-            .execute_some();
+	let owner = DefaultOwner::get();
+	let new_owner = UnpermissionedAccount::get();
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(
+				owner,
+				Precompile1,
+				PCall::transfer_ownership {
+					new_owner: precompile_utils::data::Address(new_owner),
+				},
+			)
+			.execute_some();
 
-        precompiles()
-            .prepare_test(new_owner, Precompile1, PCall::claim_ownership {})
-            .expect_log(log1(
-                Precompile1,
-                SELECTOR_LOG_NEW_OWNER,
-                EvmDataWriter::new()
-                    .write(Into::<H256>::into(new_owner))
-                    .build(),
-            ))
-            .execute_some();
+		precompiles()
+			.prepare_test(new_owner, Precompile1, PCall::claim_ownership {})
+			.expect_log(log1(
+				Precompile1,
+				SELECTOR_LOG_NEW_OWNER,
+				EvmDataWriter::new()
+					.write(Into::<H256>::into(new_owner))
+					.build(),
+			))
+			.execute_some();
 
-        precompiles()
-            .prepare_test(new_owner, Precompile1, PCall::owner {})
-            .execute_returns_encoded(Into::<H256>::into(new_owner));
-    });
+		precompiles()
+			.prepare_test(new_owner, Precompile1, PCall::owner {})
+			.execute_returns_encoded(Into::<H256>::into(new_owner));
+	});
 }
 
 #[test]
 fn mint_should_increase_balance() {
-    let target = DefaultOwner::get();
-    let amount = U256::from(1_000_000_000_000_000u128);
-    ExtBuilder::default()
-        .with_balances(vec![(
-            precompile_utils::testing::MockAccount(target),
-            0u128,
-        )])
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    target,
-                    Precompile1,
-                    PCall::mint_to {
-                        to: precompile_utils::data::Address(target),
-                        amount,
-                    },
-                )
-                .expect_log(log3(
-                    Precompile1,
-                    SELECTOR_LOG_TRANSFER,
-                    H160::from_low_u64_be(0),
-                    precompile_utils::testing::MockAccount(target),
-                    EvmDataWriter::new().write(amount).build(),
-                ))
-                .execute_some();
+	let target = DefaultOwner::get();
+	let amount = U256::from(1_000_000_000_000_000u128);
+	ExtBuilder::default()
+		.with_balances(vec![(
+			precompile_utils::testing::MockAccount(target),
+			0u128,
+		)])
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					target,
+					Precompile1,
+					PCall::mint_to {
+						to: precompile_utils::data::Address(target),
+						amount,
+					},
+				)
+				.expect_log(log3(
+					Precompile1,
+					SELECTOR_LOG_TRANSFER,
+					H160::from_low_u64_be(0),
+					precompile_utils::testing::MockAccount(target),
+					EvmDataWriter::new().write(amount).build(),
+				))
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    target,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: precompile_utils::data::Address(target),
-                    },
-                )
-                .execute_returns_encoded(amount)
-        })
+			precompiles()
+				.prepare_test(
+					target,
+					Precompile1,
+					PCall::balance_of {
+						owner: precompile_utils::data::Address(target),
+					},
+				)
+				.execute_returns_encoded(amount)
+		})
 }
 
 #[test]
 fn mint_to_different_account() {
-    let sender = DefaultOwner::get();
-    let target = UnpermissionedAccount::get();
-    let amount = U256::from(1_000_000_000_000_000u128);
+	let sender = DefaultOwner::get();
+	let target = UnpermissionedAccount::get();
+	let amount = U256::from(1_000_000_000_000_000u128);
 
-    let balances = vec![(precompile_utils::testing::MockAccount(target), 0u128)];
+	let balances = vec![(precompile_utils::testing::MockAccount(target), 0u128)];
 
-    ExtBuilder::default()
-        .with_balances(balances)
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::mint_to {
-                        to: precompile_utils::data::Address(target),
-                        amount,
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(balances)
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::mint_to {
+						to: precompile_utils::data::Address(target),
+						amount,
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: precompile_utils::data::Address(target),
-                    },
-                )
-                .execute_returns_encoded(amount)
-        })
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::balance_of {
+						owner: precompile_utils::data::Address(target),
+					},
+				)
+				.execute_returns_encoded(amount)
+		})
 }
 
 #[test]
 fn fail_mint_when_not_owner() {
-    let to = UnpermissionedAccount::get();
-    let amount = U256::from(1_000_000);
+	let to = UnpermissionedAccount::get();
+	let amount = U256::from(1_000_000);
 
-    ExtBuilder::default().build().execute_with(move || {
-        precompiles()
-            .prepare_test(
-                to,
-                Precompile1,
-                PCall::mint_to {
-                    to: precompile_utils::data::Address(to),
-                    amount,
-                },
-            )
-            .execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
-    })
+	ExtBuilder::default().build().execute_with(move || {
+		precompiles()
+			.prepare_test(
+				to,
+				Precompile1,
+				PCall::mint_to {
+					to: precompile_utils::data::Address(to),
+					amount,
+				},
+			)
+			.execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
+	})
 }
 
 #[test]
 fn fail_mint_when_overflow() {
-    let to = DefaultOwner::get();
-    let amount = U256::from(1_000_000_000);
+	let to = DefaultOwner::get();
+	let amount = U256::from(1_000_000_000);
 
-    ExtBuilder::default().build().execute_with(move || {
-        precompiles()
-            .prepare_test(
-                to,
-                Precompile1,
-                PCall::mint_to {
-                    to: precompile_utils::data::Address(to),
-                    amount: U256::MAX,
-                },
-            )
-            .execute_some();
+	ExtBuilder::default().build().execute_with(move || {
+		precompiles()
+			.prepare_test(
+				to,
+				Precompile1,
+				PCall::mint_to {
+					to: precompile_utils::data::Address(to),
+					amount: U256::MAX,
+				},
+			)
+			.execute_some();
 
-        precompiles()
-            .prepare_test(
-                to,
-                Precompile1,
-                PCall::mint_to {
-                    to: precompile_utils::data::Address(to),
-                    amount,
-                },
-            )
-            .execute_reverts(|x| {
-                x.eq_ignore_ascii_case(b"mint operation overflow account balance")
-            });
-    })
+		precompiles()
+			.prepare_test(
+				to,
+				Precompile1,
+				PCall::mint_to {
+					to: precompile_utils::data::Address(to),
+					amount,
+				},
+			)
+			.execute_reverts(|x| {
+				x.eq_ignore_ascii_case(b"mint operation overflow account balance")
+			});
+	})
 }
 
 #[test]
 fn burn_from_sender() {
-    let sender = DefaultOwner::get();
-    let burned_amount = U256::from(100);
-    let initial_balance = 1_000_000_000u128;
-    let inital_balances = vec![(
-        precompile_utils::testing::MockAccount(sender),
-        initial_balance,
-    )];
+	let sender = DefaultOwner::get();
+	let burned_amount = U256::from(100);
+	let initial_balance = 1_000_000_000u128;
+	let inital_balances = vec![(
+		precompile_utils::testing::MockAccount(sender),
+		initial_balance,
+	)];
 
-    ExtBuilder::default()
-        .with_balances(inital_balances)
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::burn_from {
-                        to: precompile_utils::data::Address(sender),
-                        amount: U256::from(burned_amount),
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(inital_balances)
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::burn_from {
+						to: precompile_utils::data::Address(sender),
+						amount: U256::from(burned_amount),
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: precompile_utils::data::Address(sender),
-                    },
-                )
-                .execute_returns_encoded(U256::from(initial_balance).sub(burned_amount));
-        })
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::balance_of {
+						owner: precompile_utils::data::Address(sender),
+					},
+				)
+				.execute_returns_encoded(U256::from(initial_balance).sub(burned_amount));
+		})
 }
 
 #[test]
 fn burn_from_not_sender() {
-    let sender = DefaultOwner::get();
-    let target = UnpermissionedAccount::get();
-    let burned_amount = U256::from(100);
-    let initial_balance = 1_000_000_000u128;
-    let inital_balances = vec![(
-        precompile_utils::testing::MockAccount(target),
-        initial_balance,
-    )];
+	let sender = DefaultOwner::get();
+	let target = UnpermissionedAccount::get();
+	let burned_amount = U256::from(100);
+	let initial_balance = 1_000_000_000u128;
+	let inital_balances = vec![(
+		precompile_utils::testing::MockAccount(target),
+		initial_balance,
+	)];
 
-    ExtBuilder::default()
-        .with_balances(inital_balances)
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::burn_from {
-                        to: precompile_utils::data::Address(target),
-                        amount: U256::from(burned_amount),
-                    },
-                )
-                .execute_some();
+	ExtBuilder::default()
+		.with_balances(inital_balances)
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::burn_from {
+						to: precompile_utils::data::Address(target),
+						amount: U256::from(burned_amount),
+					},
+				)
+				.execute_some();
 
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::balance_of {
-                        owner: precompile_utils::data::Address(target),
-                    },
-                )
-                .execute_returns_encoded(U256::from(initial_balance).sub(burned_amount));
-        })
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::balance_of {
+						owner: precompile_utils::data::Address(target),
+					},
+				)
+				.execute_returns_encoded(U256::from(initial_balance).sub(burned_amount));
+		})
 }
 
 #[test]
 fn fail_burn_from_not_owner() {
-    let sender = UnpermissionedAccount::get();
-    let burned_amount = U256::from(100);
-    let initial_balance = 1_000_000_000u128;
-    let inital_balances = vec![(
-        precompile_utils::testing::MockAccount(sender),
-        initial_balance,
-    )];
+	let sender = UnpermissionedAccount::get();
+	let burned_amount = U256::from(100);
+	let initial_balance = 1_000_000_000u128;
+	let inital_balances = vec![(
+		precompile_utils::testing::MockAccount(sender),
+		initial_balance,
+	)];
 
-    ExtBuilder::default()
-        .with_balances(inital_balances)
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::burn_from {
-                        to: precompile_utils::data::Address(sender),
-                        amount: U256::from(burned_amount),
-                    },
-                )
-                .execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
-        })
+	ExtBuilder::default()
+		.with_balances(inital_balances)
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::burn_from {
+						to: precompile_utils::data::Address(sender),
+						amount: U256::from(burned_amount),
+					},
+				)
+				.execute_reverts(|x| x.eq_ignore_ascii_case(b"sender is not owner"));
+		})
 }
 
 #[test]
 fn fail_burn_when_underflow() {
-    let sender = DefaultOwner::get();
-    let target = UnpermissionedAccount::get();
-    let burned_amount = U256::from(100);
-    let initial_balance = 1u128;
-    let inital_balances = vec![(
-        precompile_utils::testing::MockAccount(target),
-        initial_balance,
-    )];
+	let sender = DefaultOwner::get();
+	let target = UnpermissionedAccount::get();
+	let burned_amount = U256::from(100);
+	let initial_balance = 1u128;
+	let inital_balances = vec![(
+		precompile_utils::testing::MockAccount(target),
+		initial_balance,
+	)];
 
-    ExtBuilder::default()
-        .with_balances(inital_balances)
-        .build()
-        .execute_with(move || {
-            precompiles()
-                .prepare_test(
-                    sender,
-                    Precompile1,
-                    PCall::burn_from {
-                        to: precompile_utils::data::Address(target),
-                        amount: U256::from(burned_amount),
-                    },
-                )
-                .execute_reverts(|x| x.eq_ignore_ascii_case(b"not enough balance to burn"));
-        })
+	ExtBuilder::default()
+		.with_balances(inital_balances)
+		.build()
+		.execute_with(move || {
+			precompiles()
+				.prepare_test(
+					sender,
+					Precompile1,
+					PCall::burn_from {
+						to: precompile_utils::data::Address(target),
+						amount: U256::from(burned_amount),
+					},
+				)
+				.execute_reverts(|x| x.eq_ignore_ascii_case(b"not enough balance to burn"));
+		})
 }

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -537,11 +537,7 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 	}
 
 	/// Return the list of addresses contained in this PrecompileSet.
-	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
-		Self::new()
-			.inner
-			.used_addresses()
-			.into_iter()
-			.map(|x| R::AddressMapping::into_account_id(x))
+	pub fn used_addresses() -> impl Iterator<Item = H160> {
+		Self::new().inner.used_addresses().into_iter()
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -69,6 +69,8 @@ use stability_config::{
 mod precompiles;
 use precompiles::StabilityPrecompiles;
 
+pub type Precompiles = StabilityPrecompiles<Runtime>;
+
 /// Type of block number.
 pub type BlockNumber = u32;
 

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -16,26 +16,26 @@ pub struct NativeErc20Metadata;
 
 /// ERC20 metadata for the native token.
 impl Erc20Metadata for NativeErc20Metadata {
-    /// Returns the name of the token.
-    fn name() -> &'static str {
-        "DOLR"
-    }
+	/// Returns the name of the token.
+	fn name() -> &'static str {
+		"DOLR"
+	}
 
-    /// Returns the symbol of the token.
-    fn symbol() -> &'static str {
-        "DOLR"
-    }
+	/// Returns the symbol of the token.
+	fn symbol() -> &'static str {
+		"DOLR"
+	}
 
-    /// Returns the decimals places of the token.
-    fn decimals() -> u8 {
-        18
-    }
+	/// Returns the decimals places of the token.
+	fn decimals() -> u8 {
+		18
+	}
 
-    /// Must return `true` only if it represents the main native currency of
-    /// the network. It must be the currency used in `pallet_evm`.
-    fn is_native_currency() -> bool {
-        true
-    }
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool {
+		true
+	}
 }
 
 /// The asset precompile address prefix. Addresses that match against this prefix will be routed
@@ -46,39 +46,39 @@ pub const FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] = &[255u8; 4];
 pub const LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] = &[255u8, 255u8, 255u8, 254u8];
 
 parameter_types! {
-    pub ForeignAssetPrefix: &'static [u8] = FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX;
-    pub LocalAssetPrefix: &'static [u8] = LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX;
-    pub DefaultOwner:H160 = H160::from_str(DEFAULT_OWNER).expect("invalid address");
+	pub ForeignAssetPrefix: &'static [u8] = FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX;
+	pub LocalAssetPrefix: &'static [u8] = LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX;
+	pub DefaultOwner:H160 = H160::from_str(DEFAULT_OWNER).expect("invalid address");
 }
 
 // Set of Stability precompiles
 pub type StabilityPrecompiles<R> = PrecompileSetBuilder<
-    R,
-    (
-        // Skip precompiles if out of range.
-        PrecompilesInRangeInclusive<
-            (AddressU64<1>, AddressU64<4095>),
-            (
-                // Ethereum precompiles:
-                // We allow DELEGATECALL to stay compliant with Ethereum behavior.
-                PrecompileAt<AddressU64<1>, ECRecover, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<2>, Sha256, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<3>, Ripemd160, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<4>, Identity, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<5>, Modexp, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<6>, Bn128Add, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<7>, Bn128Mul, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<8>, Bn128Pairing, ForbidRecursion, AllowDelegateCall>,
-                PrecompileAt<AddressU64<9>, Blake2F, ForbidRecursion, AllowDelegateCall>,
-                // Non-Stability specific nor Ethereum precompiles :
-                PrecompileAt<AddressU64<1024>, Sha3FIPS256>,
-                PrecompileAt<AddressU64<1026>, ECRecoverPublicKey>,
-                // Stability specific precompiles:
-                PrecompileAt<
-                    AddressU64<2048>,
-                    Erc20BalancesPrecompile<R, NativeErc20Metadata, DefaultOwner>,
-                >,
-            ),
-        >,
-    ),
+	R,
+	(
+		// Skip precompiles if out of range.
+		PrecompilesInRangeInclusive<
+			(AddressU64<1>, AddressU64<4095>),
+			(
+				// Ethereum precompiles:
+				// We allow DELEGATECALL to stay compliant with Ethereum behavior.
+				PrecompileAt<AddressU64<1>, ECRecover, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<2>, Sha256, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<3>, Ripemd160, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<4>, Identity, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<5>, Modexp, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<6>, Bn128Add, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<7>, Bn128Mul, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<8>, Bn128Pairing, ForbidRecursion, AllowDelegateCall>,
+				PrecompileAt<AddressU64<9>, Blake2F, ForbidRecursion, AllowDelegateCall>,
+				// Non-Stability specific nor Ethereum precompiles :
+				PrecompileAt<AddressU64<1024>, Sha3FIPS256>,
+				PrecompileAt<AddressU64<1026>, ECRecoverPublicKey>,
+				// Stability specific precompiles:
+				PrecompileAt<
+					AddressU64<2048>,
+					Erc20BalancesPrecompile<R, NativeErc20Metadata, DefaultOwner>,
+				>,
+			),
+		>,
+	),
 >;


### PR DESCRIPTION
## Description

An error was being thrown whenever a solidity smart contract was calling a precompile. This error was due to the fact that the accounts of these contracts in EVM pallet weren't being initialized.

Additionally, all the files have been formatted.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
