### PR TITLE
chore: added default bootnode

### DIFF
--- a/docker/alphanet/entrypoint.sh
+++ b/docker/alphanet/entrypoint.sh
@@ -20,12 +20,19 @@ if [ -n "$SEED" ]; then
   --scheme Sr25519 \
   --suri "$SEED" \
   --key-type imon
+
 fi
 
 START_COMMAND="./target/release/stability --base-path /tmp/node --validator --unsafe-rpc-external --rpc-cors all --unsafe-ws-external --chain alphanet --pruning archive"
 
-if [ -n "$BOOTNODE" ]; then
-  START_COMMAND="$START_COMMAND --bootnodes $BOOTNODE"
+if [ -n "$NODE_KEY" ]; then
+  START_COMMAND="$START_COMMAND --node-key $NODE_KEY"
+fi
+
+if [ "$DEFAULT_BOOTNODE" = "yes" ]; then
+  START_COMMAND="$START_COMMAND --bootnodes /ip4/3.21.88.38/tcp/30333/p2p/12D3KooWPaen1igo2WYUFCt3EAg4AWjWoMYgmr4tCa2Yb1WfgoDB"
+elif [ -n "$BOOTNODES" ]; then
+  START_COMMAND="$START_COMMAND --bootnodes $BOOTNODES"
 fi
 
 eval $START_COMMAND


### PR DESCRIPTION
## Description

- Added the possibility to launch the alphanet with a `node-key` to have a static peer id.

- Added a default bootnode
 
## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
