### PR TITLE
fix: balance was panicking with numbers > u128::MAX

### DIFF
--- a/pallets/custom-balances/src/lib.rs
+++ b/pallets/custom-balances/src/lib.rs
@@ -115,7 +115,16 @@ pub mod pallet {
 		/// The combined balance of `who`.
 		fn total_balance(who: &T::AccountId) -> Self::Balance {
 			let evm_address = T::AccountIdMapping::into_evm_address(who);
-			<T::UserFeeTokenController as UserFeeTokenController>::balance_of(evm_address).as_u128()
+			let actual_balance =
+				<T::UserFeeTokenController as UserFeeTokenController>::balance_of(evm_address);
+
+			let maximum_balance = sp_core::U256::from(u128::MAX);
+
+			if maximum_balance < actual_balance {
+				u128::MAX
+			} else {
+				actual_balance.as_u128()
+			}
 		}
 
 		/// Same result as `slash(who, value)` (but without the side-effects) assuming there are no

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -920,7 +920,7 @@ impl_runtime_apis! {
 		}
 
 		fn account_basic(address: H160) -> EVMAccount {
-			EVM::account_basic(&address).0
+			EVMAccount { nonce: EVM::account_basic(&address).0.nonce, balance: <StabilityFeeController as FeeController>::User::balance_of(address) }
 		}
 
 		fn gas_price() -> U256 {


### PR DESCRIPTION
## Description

This is a workaround since native transfers over a u128::MAX doesn't work properly. It'd be necessary to execute a `transfer` directly to the ERC20 address.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
