### PR TITLE
Fix block gas used over limit

### DIFF
--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -25,12 +25,12 @@ Having this relationship between these two limits, we can create a unique limit 
 
 Additionally, in Substrate there is a constant (`WEIGHT_REF_TIME_PER_MILLIS`) that marks how much weight could be processed in a millisecond.
 
-This is useful because introducing some of the blockchain's parameters we could know if certain block specifications are achieveable so when the blockchain is initalized this check is runned. If this check fails the blockchain would exit.
+Using this value and estimating the share of the block time that is spent in computing it we reach to the block gas limit
 
 - **COMPUTATION_BLOCK_TIME_RATIO**: How much part of the block time could be spent in processing transactions.
-- **MAXIMUM_NORMAL_BLOCK_WEIGHT**: The maximum weight that could be processed given the block time and `COMPUTATION_BLOCK_TIME_RATIO`
+- **MAXIMUM_BLOCK_WEIGHT**: The maximum weight that could be processed given the block time and `COMPUTATION_BLOCK_TIME_RATIO`
   - MAXIMUM_NORMAL_BLOCK_WEIGHT = 1_333_333_333_333
-- **Target Gas Limit**: ~50_000_000. Frontier assumes that a Gas Unit is equals to 20_000 Weight (`WEIGHT_PER_GAS`), and the blocks would allow till 75% (`NORMAL_DISPATCH_RATIO`) of `Normal` extrinsics in each one. The formula looks like:
+- **Block Gas Limit**: ~50_000_000. Frontier assumes that a Gas Unit is equals to 20_000 Weight (`WEIGHT_PER_GAS`), and the blocks would allow till 75% (`NORMAL_DISPATCH_RATIO`) of `Normal` extrinsics in each one. The formula looks like:
 
 ```
 Gas Limit = NORMAL_DISPATCH_RATIO * MBW / WEIGHT_PER_GAS

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,6 +47,7 @@ use sp_runtime::{
 };
 use sp_std::{marker::PhantomData, prelude::*};
 use sp_version::RuntimeVersion;
+use stability_config::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
 use stbl_core_primitives::aura::Public as AuraId;
 use stbl_core_primitives::imonline::Public as ImOnlineId;
 use stbl_transaction_validator::FallbackTransactionValidator;
@@ -81,10 +82,9 @@ use pallet_user_fee_selector;
 
 mod stability_config;
 use stability_config::{
-	build_block_weights, COUNCIL_MAX_MEMBERS, COUNCIL_MAX_PROPOSALS,
-	COUNCIL_MOTION_MINUTES_DURATION, DEFAULT_ELASTICITY, DEFAULT_FEE_TOKEN, EXISTENTIAL_DEPOSIT,
-	GAS_BASE_FEE, MAXIMUM_BLOCK_LENGTH, MILLISECS_PER_BLOCK, SESSION_MINUTES_DURATION,
-	VALIDATOR_SET_MIN_VALIDATORS,
+	COUNCIL_MAX_MEMBERS, COUNCIL_MAX_PROPOSALS, COUNCIL_MOTION_MINUTES_DURATION,
+	DEFAULT_ELASTICITY, DEFAULT_FEE_TOKEN, EXISTENTIAL_DEPOSIT, GAS_BASE_FEE, MAXIMUM_BLOCK_LENGTH,
+	MILLISECS_PER_BLOCK, SESSION_MINUTES_DURATION, VALIDATOR_SET_MIN_VALIDATORS,
 };
 
 mod precompiles;
@@ -880,11 +880,11 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
 }
 
 parameter_types! {
-	pub BlockWeights: frame_system::limits::BlockWeights = build_block_weights();
+	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO);
 
 	pub BlockGasLimit : U256 = {
-		let max_normal_extrinsic_weight = BlockWeights::get().get(DispatchClass::Normal).max_extrinsic.expect("invalid max_extrinsic").ref_time();
-		U256::from(max_normal_extrinsic_weight / WEIGHT_PER_GAS)
+		let max_normal_block_usage = BlockWeights::get().get(DispatchClass::Normal).max_total.expect("invalid max_extrinsic").ref_time();
+		U256::from(max_normal_block_usage / WEIGHT_PER_GAS)
 	};
 
 }

--- a/runtime/src/stability_config.rs
+++ b/runtime/src/stability_config.rs
@@ -12,6 +12,8 @@ use crate::WEIGHT_PER_GAS;
 // Block time
 pub const MILLISECS_PER_BLOCK: u64 = 2000;
 
+pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+
 /// How much of time of block time is consumed (at most) in computing normal extrinsics
 const COMPUTATION_BLOCK_TIME_RATIO: (u64, u64) = (2, 3); // 2 third parts of the block time
 
@@ -52,45 +54,6 @@ pub const SESSION_MINUTES_DURATION: u32 = 2;
 pub const VALIDATOR_SET_MIN_VALIDATORS: u32 = 1;
 
 pub const TARGET_BLOCK_GAS_LIMIT: u64 = 50_000_000u64;
-
-// Since BlockWeights::builder is not a const function we have to embed into a function
-// It uses TARGET_BLOCK_GAS_LIMIT to set the block_weights limitations
-// It checks using MAXIMUM_NORMAL_BLOCK_WEIGHT that the target is
-// achieveable.
-pub fn build_block_weights() -> frame_system::limits::BlockWeights {
-	let normal_max_extrinsic = Weight::from_ref_time(TARGET_BLOCK_GAS_LIMIT * WEIGHT_PER_GAS);
-
-	let normal_max_weight = normal_max_extrinsic
-		.add(2 * ExtrinsicBaseWeight::get().ref_time())
-		.mul(10)
-		.div(9);
-
-	let weights = frame_system::limits::BlockWeights::builder()
-		.for_class(DispatchClass::Normal, |weights| {
-			weights.max_extrinsic = Some(normal_max_extrinsic).map(|x| x.set_proof_size(u64::MAX));
-			weights.max_total = Some(normal_max_weight).map(|x| x.set_proof_size(u64::MAX));
-		})
-		.for_class(DispatchClass::Operational, |weights| {
-			let reserved = OPERATION_RESERVE_FACTOR * normal_max_extrinsic.set_proof_size(0);
-			weights.max_total =
-				Some(normal_max_weight + reserved).map(|x| x.set_proof_size(u64::MAX));
-			weights.reserved = Some(reserved).map(|x| x.set_proof_size(u64::MAX));
-			weights.max_extrinsic = weights
-				.max_total
-				.map(|total| total - total.div(10) - ExtrinsicBaseWeight::get())
-				.map(|x| x.set_proof_size(u64::MAX))
-				.into();
-		})
-		.build()
-		.expect("Sensible defaults are tested to be valid; qed");
-
-	assert!(
-		weights.max_block.ref_time() <= MAXIMUM_BLOCK_WEIGHT.ref_time(),
-		"max_block weight is not computable under the given circustances"
-	);
-
-	weights
-}
 
 // Gas Base Fee
 pub const GAS_BASE_FEE: u128 = 1_000_000_000;


### PR DESCRIPTION
## Description

In https://github.com/stabilityprotocol/stability/pull/30/  **EVM block gas limit** calculation was configured in order to match **Max EVM transaction gas limit**  this leaded to Substrate block gas limit to be a bit over the **EVM block gas limit**. Since in EVM there is no control for not overpass BlockGasLimit and Substrate's wasn't overpass blocks could be filled up over the **EVM block gas limit**

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
