### PR TITLE
Add missing runtime std

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -57,6 +57,7 @@ std = [
     'pallet-root-controller/std',
     'pallet-supported-tokens-manager/std',
     'pallet-validator-set/std',
+    'pallet-validator-fee-selector/std',
     'pallet-session/std',
     'pallet-im-online/std',
     'pallet-upgrade-runtime-proposal/std',


### PR DESCRIPTION
## Description

Missing `std` dependency in runtime that was making unable to upgrade the blockchain or compiling the wasm file

## Types of changes

What types of changes does your code introduce?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
