### PR TITLE
Conversion rate limitted by trx type 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8813,6 +8813,7 @@ name = "stbl-tools"
 version = "0.1.0"
 dependencies = [
  "ethereum",
+ "fp-ethereum",
  "hex",
  "pallet-evm",
  "sha3 0.10.8",

--- a/pallets/validator-set/src/mock.rs
+++ b/pallets/validator-set/src/mock.rs
@@ -109,8 +109,8 @@ pub struct TestShouldEndSession;
 impl ShouldEndSession<u64> for TestShouldEndSession {
 	fn should_end_session(now: u64) -> bool {
 		let l = SESSION_LENGTH.with(|l| *l.borrow());
-		now % l == 0 ||
-			FORCE_SESSION_END.with(|l| {
+		now % l == 0
+			|| FORCE_SESSION_END.with(|l| {
 				let r = *l.borrow();
 				*l.borrow_mut() = false;
 				r
@@ -123,9 +123,16 @@ pub fn authorities() -> Vec<UintAuthorityId> {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	let keys: Vec<_> = NEXT_VALIDATORS
-		.with(|l| l.borrow().iter().cloned().map(|i| (i, i, UintAuthorityId(i).into())).collect());
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+	let keys: Vec<_> = NEXT_VALIDATORS.with(|l| {
+		l.borrow()
+			.iter()
+			.cloned()
+			.map(|i| (i, i, UintAuthorityId(i).into()))
+			.collect()
+	});
 	BasicExternalities::execute_with_storage(&mut t, || {
 		for (ref k, ..) in &keys {
 			frame_system::Pallet::<Test>::inc_providers(k);

--- a/primitives/runner/src/lib.rs
+++ b/primitives/runner/src/lib.rs
@@ -144,35 +144,13 @@ where
 			});
 		}
 
-		let (total_fee_per_gas, _actual_priority_fee_per_gas) =
-			match (max_fee_per_gas, max_priority_fee_per_gas, is_transactional) {
-				// Zero max_fee_per_gas for validated transactional calls exist in XCM -> EVM
-				// because fees are already withdrawn in the xcm-executor.
-				(Some(max_fee), _, true) if max_fee.is_zero() => (U256::zero(), U256::zero()),
-				// With no tip, we pay exactly the base_fee
-				(Some(_), None, _) => (base_fee, U256::zero()),
-				// With tip, we include as much of the tip on top of base_fee that we can, never
-				// exceeding max_fee_per_gas
-				(Some(max_fee_per_gas), Some(max_priority_fee_per_gas), _) => {
-					let actual_priority_fee_per_gas = max_fee_per_gas
-						.saturating_sub(base_fee)
-						.min(max_priority_fee_per_gas);
-					(
-						base_fee.saturating_add(actual_priority_fee_per_gas),
-						actual_priority_fee_per_gas,
-					)
-				}
-				// Gas price check is skipped for non-transactional calls that don't
-				// define a `max_fee_per_gas` input.
-				(None, _, false) => (Default::default(), U256::zero()),
-				// Unreachable, previously validated. Handle gracefully.
-				_ => {
-					return Err(RunnerError {
-						error: Error::<T>::GasPriceTooLow,
-						weight,
-					})
-				}
-			};
+		let custom_fee_info = stbl_tools::custom_fee::custom_info_from_fee_params(
+			base_fee,
+			max_fee_per_gas.unwrap(),
+			max_priority_fee_per_gas,
+		);
+
+		let total_fee_per_gas = custom_fee_info.max_fee_per_gas;
 
 		// After eip-1559 we make sure the account can pay both the evm execution and priority fees.
 		let total_fee =
@@ -187,12 +165,22 @@ where
 		let validator = <pallet_evm::Pallet<T>>::find_author();
 		let vault = FC::get_fee_vault();
 
-		let conversion_rate = FC::get_transaction_conversion_rate(source, validator, token);
+		let validator_conversion_rate =
+			FC::get_transaction_conversion_rate(source, validator, token);
+
+		let actual_conversion_rate =
+			if custom_fee_info.match_validator_conversion_rate_limit(validator_conversion_rate) {
+				validator_conversion_rate
+			} else {
+				custom_fee_info.max_conversion_rate.unwrap()
+			};
 
 		// Deduct fee from the `source` account. Returns `None` if `total_fee` is Zero.
-		FC::withdraw_fee(source, token, conversion_rate, total_fee).map_err(|_| RunnerError {
-			error: Error::<T>::FeeOverflow,
-			weight,
+		FC::withdraw_fee(source, token, actual_conversion_rate, total_fee).map_err(|_| {
+			RunnerError {
+				error: Error::<T>::FeeOverflow,
+				weight,
+			}
 		})?;
 
 		// Execute the EVM call.
@@ -224,20 +212,20 @@ where
 			is_transactional
 		);
 
-		FC::correct_fee(source, token, conversion_rate, total_fee, actual_fee).map_err(|_| {
-			RunnerError {
+		FC::correct_fee(source, token, actual_conversion_rate, total_fee, actual_fee).map_err(
+			|_| RunnerError {
 				error: Error::<T>::FeeOverflow,
 				weight,
-			}
-		})?;
+			},
+		)?;
 
 		let (validator_fee, dapp_fee) =
-			FC::pay_fees(token, conversion_rate, actual_fee, validator, dapp).map_err(|_| {
-				RunnerError {
+			FC::pay_fees(token, actual_conversion_rate, actual_fee, validator, dapp).map_err(
+				|_| RunnerError {
 					error: Error::<T>::FeeOverflow,
 					weight,
-				}
-			})?;
+				},
+			)?;
 
 		executor
 			.log(

--- a/primitives/runner/src/lib.rs
+++ b/primitives/runner/src/lib.rs
@@ -146,7 +146,7 @@ where
 
 		let custom_fee_info = stbl_tools::custom_fee::custom_info_from_fee_params(
 			base_fee,
-			max_fee_per_gas.unwrap(),
+			max_fee_per_gas,
 			max_priority_fee_per_gas,
 		);
 

--- a/primitives/tools/Cargo.toml
+++ b/primitives/tools/Cargo.toml
@@ -12,5 +12,10 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-io = { workspace = true }
 ethereum = { workspace = true }
+fp-ethereum = { workspace = true }
 sha3 = { version = "0.10.6", default-features = false }
-hex = {workspace= true, default-features = false    }
+hex = {workspace= true, default-features = false }
+
+
+[dev-dependencies]
+pallet-evm = { workspace = true, features = ["std"] }

--- a/primitives/tools/src/custom_fee.rs
+++ b/primitives/tools/src/custom_fee.rs
@@ -1,0 +1,81 @@
+use ethereum::TransactionV2;
+use fp_ethereum::TransactionData;
+use sp_core::U256;
+
+pub struct CustomFeeInfo {
+	pub max_conversion_rate: Option<(U256, U256)>,
+	pub max_fee_per_gas: U256,
+	pub max_priority_fee_per_gas: Option<U256>,
+}
+
+impl CustomFeeInfo {
+	pub fn new(base_fee: U256, transaction: &TransactionV2) -> Self {
+		let data: TransactionData = transaction.into();
+		custom_info_from_fee_params(
+			base_fee,
+			data.max_fee_per_gas.or(data.gas_price).unwrap(),
+			data.max_priority_fee_per_gas,
+		)
+	}
+}
+
+pub fn custom_info_from_fee_params(
+	base_fee: U256,
+	max_fee_per_gas: U256,
+	max_priority_fee_per_gas: Option<U256>,
+) -> CustomFeeInfo {
+	CustomFeeInfo {
+		max_conversion_rate: max_priority_fee_per_gas
+			.map(|_| (max_fee_per_gas, 1_000_000_000.into())),
+		max_fee_per_gas: max_priority_fee_per_gas
+			.map(|max_priority_fee_per_gas| max_priority_fee_per_gas.saturating_add(base_fee))
+			.unwrap_or(max_fee_per_gas),
+		max_priority_fee_per_gas,
+	}
+}
+
+impl CustomFeeInfo {
+	pub fn match_validator_conversion_rate_limit(
+		&self,
+		validator_conversion_rate: (U256, U256),
+	) -> bool {
+		if let Some(max_conversion_rate) = self.max_conversion_rate {
+			max_conversion_rate.0 * validator_conversion_rate.1
+				>= max_conversion_rate.1 * validator_conversion_rate.0
+		} else {
+			true
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use sp_core::U256;
+
+	#[test]
+	fn custom_info_from_fee_params_for_trx_v1() {
+		let info =
+			custom_info_from_fee_params(U256::from(1_000_000_000), U256::from(1_000_000_000), None);
+
+		assert_eq!(info.max_priority_fee_per_gas, None);
+		assert_eq!(info.max_fee_per_gas, U256::from(1_000_000_000));
+		assert_eq!(info.max_conversion_rate, None);
+	}
+
+	#[test]
+	fn custom_info_from_fee_params_for_trx_v2() {
+		let info = custom_info_from_fee_params(
+			U256::from(1_000_000_000),
+			U256::from(2_000_000_000),
+			Some(U256::from(500_000_000)),
+		);
+
+		assert_eq!(info.max_priority_fee_per_gas, Some(U256::from(500_000_000)));
+		assert_eq!(info.max_fee_per_gas, U256::from(1_500_000_000));
+		assert_eq!(
+			info.max_conversion_rate,
+			Some((U256::from(2_000_000_000), U256::from(1_000_000_000)))
+		);
+	}
+}

--- a/primitives/tools/src/custom_fee.rs
+++ b/primitives/tools/src/custom_fee.rs
@@ -13,7 +13,7 @@ impl CustomFeeInfo {
 		let data: TransactionData = transaction.into();
 		custom_info_from_fee_params(
 			base_fee,
-			data.max_fee_per_gas.or(data.gas_price).unwrap(),
+			data.max_fee_per_gas.or(data.gas_price),
 			data.max_priority_fee_per_gas,
 		)
 	}
@@ -21,15 +21,15 @@ impl CustomFeeInfo {
 
 pub fn custom_info_from_fee_params(
 	base_fee: U256,
-	max_fee_per_gas: U256,
+	max_fee_per_gas: Option<U256>,
 	max_priority_fee_per_gas: Option<U256>,
 ) -> CustomFeeInfo {
 	CustomFeeInfo {
 		max_conversion_rate: max_priority_fee_per_gas
-			.map(|_| (max_fee_per_gas, 1_000_000_000.into())),
+			.map(|_| (max_fee_per_gas.unwrap(), 1_000_000_000.into())),
 		max_fee_per_gas: max_priority_fee_per_gas
 			.map(|max_priority_fee_per_gas| max_priority_fee_per_gas.saturating_add(base_fee))
-			.unwrap_or(max_fee_per_gas),
+			.unwrap_or(max_fee_per_gas.unwrap_or_default()),
 		max_priority_fee_per_gas,
 	}
 }
@@ -55,8 +55,11 @@ mod test {
 
 	#[test]
 	fn custom_info_from_fee_params_for_trx_v1() {
-		let info =
-			custom_info_from_fee_params(U256::from(1_000_000_000), U256::from(1_000_000_000), None);
+		let info = custom_info_from_fee_params(
+			U256::from(1_000_000_000),
+			Some(U256::from(1_000_000_000)),
+			None,
+		);
 
 		assert_eq!(info.max_priority_fee_per_gas, None);
 		assert_eq!(info.max_fee_per_gas, U256::from(1_000_000_000));
@@ -67,7 +70,7 @@ mod test {
 	fn custom_info_from_fee_params_for_trx_v2() {
 		let info = custom_info_from_fee_params(
 			U256::from(1_000_000_000),
-			U256::from(2_000_000_000),
+			Some(U256::from(2_000_000_000)),
 			Some(U256::from(500_000_000)),
 		);
 
@@ -77,5 +80,14 @@ mod test {
 			info.max_conversion_rate,
 			Some((U256::from(2_000_000_000), U256::from(1_000_000_000)))
 		);
+	}
+
+	#[test]
+	fn custom_info_from_fee_params_for_read_trx() {
+		let info = custom_info_from_fee_params(U256::from(1_000_000_000), None, None);
+
+		assert_eq!(info.max_priority_fee_per_gas, None);
+		assert_eq!(info.max_fee_per_gas, U256::from(0));
+		assert_eq!(info.max_conversion_rate, None);
 	}
 }

--- a/primitives/tools/src/eth.rs
+++ b/primitives/tools/src/eth.rs
@@ -130,11 +130,9 @@ pub fn transaction_gas_price(
 ) -> Result<U256, ()> {
 	let data: TransactionData = transaction.into();
 
-	let effective_gas_price = crate::some_or_err!(data.max_fee_per_gas.or(data.gas_price), || ());
-
 	let max_fee_per_gas = crate::custom_fee::custom_info_from_fee_params(
 		base_fee,
-		effective_gas_price,
+		data.max_fee_per_gas.or(data.gas_price),
 		data.max_priority_fee_per_gas,
 	)
 	.max_fee_per_gas;

--- a/primitives/tools/src/eth.rs
+++ b/primitives/tools/src/eth.rs
@@ -1,4 +1,5 @@
 pub use ethereum::TransactionV2 as Transaction;
+use fp_ethereum::TransactionData;
 use sha3::Digest;
 use sp_core::U256;
 use sp_core::{Encode, H160, H256};
@@ -127,33 +128,21 @@ pub fn transaction_gas_price(
 	transaction: &Transaction,
 	is_transactional: bool,
 ) -> Result<U256, ()> {
-	let (max_fee_per_gas, max_priority_fee_per_gas) = {
-		match transaction {
-			Transaction::Legacy(t) => (Some(t.gas_price), Some(t.gas_price)),
-			Transaction::EIP2930(t) => (Some(t.gas_price), Some(t.gas_price)),
-			Transaction::EIP1559(t) => (Some(t.max_fee_per_gas), Some(t.max_priority_fee_per_gas)),
-		}
-	};
+	let data: TransactionData = transaction.into();
 
-	match (max_fee_per_gas, max_priority_fee_per_gas, is_transactional) {
-		// Zero max_fee_per_gas for validated transactional calls exist in XCM -> EVM
-		// because fees are already withdrawn in the xcm-executor.
-		(Some(max_fee), _, true) if max_fee.is_zero() => Ok(U256::zero()),
-		// With no tip, we pay exactly the base_fee
-		(Some(_), None, _) => Ok(base_fee.into()),
-		// With tip, we include as much of the tip on top of base_fee that we can, never
-		// exceeding max_fee_per_gas
-		(Some(max_fee_per_gas), Some(max_priority_fee_per_gas), _) => {
-			let actual_priority_fee_per_gas = max_fee_per_gas
-				.saturating_sub(base_fee.into())
-				.min(max_priority_fee_per_gas);
-			Ok(actual_priority_fee_per_gas.saturating_add(base_fee.into()))
-		}
-		// Gas price check is skipped for non-transactional calls that don't
-		// define a `max_fee_per_gas` input.
-		(None, _, false) => Ok(Default::default()),
-		// Unreachable, previously validated. Handle gracefully.
-		_ => Err(()),
+	let effective_gas_price = crate::some_or_err!(data.max_fee_per_gas.or(data.gas_price), || ());
+
+	let max_fee_per_gas = crate::custom_fee::custom_info_from_fee_params(
+		base_fee,
+		effective_gas_price,
+		data.max_priority_fee_per_gas,
+	)
+	.max_fee_per_gas;
+
+	if max_fee_per_gas < base_fee && is_transactional {
+		return Err(());
+	} else {
+		Ok(max_fee_per_gas)
 	}
 }
 

--- a/primitives/tools/src/lib.rs
+++ b/primitives/tools/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod custom_fee;
 pub mod eth;
 pub mod misc;

--- a/primitives/transaction-validator/src/lib.rs
+++ b/primitives/transaction-validator/src/lib.rs
@@ -69,19 +69,26 @@ where
 
 		let (account, _) = pallet_evm::Pallet::<T>::account_basic(origin);
 
+		let base_fee = <T as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
+
 		CheckEvmTransaction::<InvalidTransactionWrapper>::new(
 			CheckEvmTransactionConfig {
 				evm_config: <T as pallet_evm::Config>::config(),
 				block_gas_limit: <T as pallet_evm::Config>::BlockGasLimit::get(),
-				base_fee: <T as pallet_evm::Config>::FeeCalculator::min_gas_price().0,
+				base_fee: base_fee.clone(),
 				chain_id: <T as pallet_evm::Config>::ChainId::get(),
 				is_transactional: true,
 			},
 			transaction_data.clone().into(),
 		)
 		.validate_in_pool_for(&account)
-		.and_then(|v| v.with_base_fee())
 		.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+
+		if gas_price < base_fee {
+			return Err(TransactionValidityError::Invalid(
+				InvalidTransaction::Payment,
+			));
+		}
 
 		ValidTransactionBuilder::default()
 			.and_provides((origin, transaction_data.nonce))

--- a/primitives/transaction-validator/src/lib.rs
+++ b/primitives/transaction-validator/src/lib.rs
@@ -36,7 +36,7 @@ where
 			let base_fee = <T as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
 
 			let gas_price = stbl_tools::eth::transaction_gas_price(base_fee, &transaction, true)
-				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Custom(0)))?;
+				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
 
 			let transaction_data: TransactionData = (transaction).into();
 			let total_transaction_price =

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,6 +50,7 @@ use sp_version::RuntimeVersion;
 use stability_config::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
 use stbl_core_primitives::aura::Public as AuraId;
 use stbl_core_primitives::imonline::Public as ImOnlineId;
+use stbl_tools::custom_fee::CustomFeeInfo;
 use stbl_transaction_validator::FallbackTransactionValidator;
 // Substrate FRAME
 #[cfg(feature = "with-paritydb-weights")]
@@ -1204,8 +1205,15 @@ impl_runtime_apis! {
 
 				let source_address = source_address_option.unwrap();
 
-
 				let source_fee_token = <pallet_user_fee_selector::Pallet<Runtime>>::get_user_fee_token(source_address);
+
+				let validator_conversion_rate = <pallet_validator_fee_selector::Pallet<Runtime>>::conversion_rate(source_address, validator.into(), source_fee_token);
+
+				let custom_fee_info = CustomFeeInfo::new(BaseFee::base_fee_per_gas(), &transaction);
+
+				if !custom_fee_info.match_validator_conversion_rate_limit(validator_conversion_rate) {
+					return false
+				}
 
 				<pallet_validator_fee_selector::Pallet<Runtime>>::validator_supports_fee_token(validator.into(), source_fee_token)
 			} else if let RuntimeCall::MetaTransactions(send_sponsored_transaction { transaction, .. }) = tx.0.function {
@@ -1219,6 +1227,15 @@ impl_runtime_apis! {
 
 
 				let source_fee_token = <pallet_user_fee_selector::Pallet<Runtime>>::get_user_fee_token(source_address);
+
+
+				let validator_conversion_rate = <pallet_validator_fee_selector::Pallet<Runtime>>::conversion_rate(source_address, validator.into(), source_fee_token);
+
+				let custom_fee_info = CustomFeeInfo::new(BaseFee::base_fee_per_gas(), &transaction);
+
+				if !custom_fee_info.match_validator_conversion_rate_limit(validator_conversion_rate) {
+					return false
+				}
 
 				<pallet_validator_fee_selector::Pallet<Runtime>>::validator_supports_fee_token(validator.into(), source_fee_token)
 			}


### PR DESCRIPTION
## Description

Modifies transaction type 2 behaviour in such way that `max_fee_per_gas` doesn't determines the maximum spendable amount of fee per gas but it determines the `max_conversion_rate` (1 gwei -> represents (1e9, 1e9))).

The effective transaction gasPrice is calculated by the sum of the constant base fee `(1 Gwei)` plus the `max_priority_fee_per_gas` field. 

There are two known limitations interacting with MetaMask:

* Field `max_priority_fee_per_gas` cannot be higher than `max_fee_per_gas`
* High `max_conversion_rate` values (max_fee_per_gas) might lead to MetaMask throw errors of not enough balance

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
