### PR TITLE
Fix unsafe usage of arithmetic ops (SlowMist N2)

### DIFF
--- a/pallets/custom-balances/src/lib.rs
+++ b/pallets/custom-balances/src/lib.rs
@@ -86,16 +86,16 @@ pub mod pallet {
 
 		fn split(self, amount: T) -> (Self, Self) {
 			let first = self.0.min(amount);
-			let second = self.0 - first;
+			let second = self.0.saturating_sub(first);
 			(Self::new(first), Self::new(second))
 		}
 
 		fn merge(self, other: Self) -> Self {
-			Self::new(self.0 + other.0)
+			Self::new(self.0.saturating_add(other.0))
 		}
 
 		fn subsume(&mut self, other: Self) {
-			self.0 += other.0;
+			self.0 = self.0.saturating_add(other.0);
 		}
 
 		fn offset(self, _other: Self::Opposite) -> SameOrOther<Self, Self> {

--- a/pallets/dnt-fee-controller/src/lib.rs
+++ b/pallets/dnt-fee-controller/src/lib.rs
@@ -176,15 +176,14 @@ pub mod pallet {
 			};
 
 			let validator_fee = fee_in_user_token
-				.checked_mul(validator_share.into())
-				.map(|v| v.div_mod(U256::from(100)).0);
+				.saturating_mul(validator_share.into())
+				.div_mod(U256::from(100))
+				.0;
 
-			let validator_fee = match validator_fee {
-				Some(a) => a,
-				None => return Err(Error::ArithmeticError),
+			let dapp_fee = match fee_in_user_token.checked_sub(validator_fee) {
+				Some(v) => v,
+				None => return Err(Error::<T>::FeeVaultOverflow),
 			};
-
-			let dapp_fee = fee_in_user_token - validator_fee;
 
 			pallet_fee_rewards_vault::Pallet::<T>::add_claimable_reward(
 				validator,

--- a/pallets/sponsored-transactions/src/lib.rs
+++ b/pallets/sponsored-transactions/src/lib.rs
@@ -77,10 +77,19 @@ pub mod pallet {
 
 					let (transaction_fee_token, _) = Self::get_fee_token_info(&from);
 
+					let max_gas_used = match gas_price.checked_mul(transaction_data.gas_limit) {
+						Some(v) => v,
+						None => {
+							return Err(TransactionValidityError::Invalid(
+								InvalidTransaction::Custom(1),
+							))
+						}
+					};
+
 					Self::ensure_sponsor_balance(
 						meta_trx_sponsor.clone(),
 						transaction_fee_token,
-						gas_price * transaction_data.gas_limit,
+						max_gas_used,
 					)
 					.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
 
@@ -117,7 +126,9 @@ pub mod pallet {
 			meta_trx_sponsor: H160,
 			meta_trx_sponsor_signature: Vec<u8>,
 		) -> DispatchResult {
-			SponsorNonce::<T>::mutate(meta_trx_sponsor.clone(), |nonce| *nonce += 1);
+			SponsorNonce::<T>::mutate(meta_trx_sponsor.clone(), |nonce| {
+				*nonce = nonce.saturating_add(1)
+			});
 
 			let from = Self::ensure_transaction_signature(transaction.clone())
 				.map_err(|_| DispatchError::Other("Invalid transaction signature"))?;

--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -24,7 +24,7 @@ use frame_support::{
 };
 use log;
 pub use pallet::*;
-use sp_runtime::traits::{Convert, Zero};
+use sp_runtime::traits::{Convert, Saturating, Zero};
 use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 
 pub const LOG_TARGET: &'static str = "runtime::validator-set";
@@ -550,7 +550,10 @@ impl<T: Config> Pallet<T> {
 
 // Provides the new set of validators to the session module when session is
 // being rotated.
-impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
+impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T>
+where
+	T::BlockNumber: Saturating,
+{
 	// Plan a new session and provide new validator set.
 
 	fn new_session(_new_index: u32) -> Option<Vec<T::AccountId>> {
@@ -572,7 +575,8 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
 
 		// Get current block number
 		let session_start_block = T::SessionBlockManager::session_start_block(end_index);
-		let session_end_block = T::SessionBlockManager::session_start_block(end_index + 1);
+		let session_end_block =
+			T::SessionBlockManager::session_start_block(end_index.saturating_add(1));
 
 		let mut epoch_block_authors = BTreeSet::<T::AccountId>::new();
 
@@ -583,7 +587,7 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
 			if let Some(author) = block_author {
 				epoch_block_authors.insert(author);
 			}
-			i += 1u32.into();
+			i.saturating_inc();
 		}
 
 		for validator in validators {


### PR DESCRIPTION
## Description

Slowmist problem description:

In Rust, numeric variables used in calculations without proper overflow checks, such as checked_add ,
checked_mul , or checked_sub , may be susceptible to integer overflow. Integer overflow occurs when the result
of an arithmetic operation exceeds the maximum value that the data type can represent, leading to an unexpected
and potentially unsafe outcome.

Our response:

Suggested changes partially applied. 

For some of the required interfaces (e.g `pallet-custom-balances`) there is no possibility for throwing an error other than panicking. This mechanism is unwanted because could lead to unexpected behaviour so we decided to decided to interpret which case is better in each case to do in case of overflow. For most of the cases, the best solution has been to use `Saturating` trait and lose some precision in those cases. 

This loose of precision are not real potential risks since in most cases these saturating ops. are referred to block numbers or nonces. Having a 32-byte long number make our blockchain invulnerable for trillions of years.  

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
