### PR TITLE
Fix call tracer for `debug_traceTransaction`

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -177,7 +177,7 @@ pub fn base_genesis(
 				map.insert(
 					main_account,
 					fp_evm::GenesisAccount {
-						nonce: U256::from(2),
+						nonce: U256::from(1),
 						balance: Default::default(),
 						storage: Default::default(),
 						code: Default::default(),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{bytes::from_hex, ecdsa, H160, H256, U256};
+use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use stability_runtime::{AccountId, GenesisConfig, Precompiles, ValidatorFeeSelectorConfig};
 use std::{collections::BTreeMap, str::FromStr, vec};
 // Substrate
@@ -13,8 +13,8 @@ use stability_runtime::{opaque::SessionKeys, EnableManualSeal, Signature};
 pub mod alphanet;
 pub mod betanet;
 pub mod dev;
-pub mod mainnet;
 pub mod testnet;
+pub mod mainnet;
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -147,17 +147,19 @@ pub fn base_genesis(
 			accounts: {
 				let mut map = BTreeMap::new();
 				let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-				Precompiles::used_addresses().into_iter().for_each(|addr| {
-					map.insert(
-						H160(addr.0),
-						fp_evm::GenesisAccount {
-							nonce: Default::default(),
-							balance: Default::default(),
-							storage: Default::default(),
-							code: revert_bytecode.clone(),
-						},
-					);
-				});
+				Precompiles::used_addresses()
+					.into_iter()
+					.for_each(|addr| {
+						map.insert(
+							H160(addr.0),
+							fp_evm::GenesisAccount {
+								nonce: Default::default(),
+								balance: Default::default(),
+								storage: Default::default(),
+								code: revert_bytecode.clone(),
+							},
+						);
+					});
 				map.insert(initial_default_token, fp_evm::GenesisAccount {
 					nonce: Default::default(),
 					balance: Default::default(),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sp_core::{bytes::from_hex, ecdsa, H160, H256, U256};
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
+use sp_core::{bytes::from_hex, ecdsa, H160, H256, U256};
 use stability_runtime::{AccountId, GenesisConfig, Precompiles, ValidatorFeeSelectorConfig};
 use std::{collections::BTreeMap, str::FromStr, vec};
 // Substrate
@@ -13,8 +13,8 @@ use stability_runtime::{opaque::SessionKeys, EnableManualSeal, Signature};
 pub mod alphanet;
 pub mod betanet;
 pub mod dev;
-pub mod testnet;
 pub mod mainnet;
+pub mod testnet;
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -147,19 +147,17 @@ pub fn base_genesis(
 			accounts: {
 				let mut map = BTreeMap::new();
 				let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-				Precompiles::used_addresses()
-					.into_iter()
-					.for_each(|addr| {
-						map.insert(
-							H160(addr.0),
-							fp_evm::GenesisAccount {
-								nonce: Default::default(),
-								balance: Default::default(),
-								storage: Default::default(),
-								code: revert_bytecode.clone(),
-							},
-						);
-					});
+				Precompiles::used_addresses().into_iter().for_each(|addr| {
+					map.insert(
+						H160(addr.0),
+						fp_evm::GenesisAccount {
+							nonce: Default::default(),
+							balance: Default::default(),
+							storage: Default::default(),
+							code: revert_bytecode.clone(),
+						},
+					);
+				});
 				map.insert(initial_default_token, fp_evm::GenesisAccount {
 					nonce: Default::default(),
 					balance: Default::default(),
@@ -179,7 +177,7 @@ pub fn base_genesis(
 				map.insert(
 					main_account,
 					fp_evm::GenesisAccount {
-						nonce: U256::from(1),
+						nonce: U256::from(2),
 						balance: Default::default(),
 						storage: Default::default(),
 						code: Default::default(),

--- a/vendor/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/vendor/client/evm-tracing/src/formatters/call_tracer.rs
@@ -43,6 +43,7 @@ impl super::ResponseFormatter for Formatter {
 		for entry in listener.entries.iter() {
 			let mut result: Vec<Call> = entry
 				.into_iter()
+				.filter(|(_, it)| it.from.ne(&H160::zero()))
 				.map(|(_, it)| {
 					let from = it.from;
 					let trace_address = it.trace_address.clone();
@@ -208,7 +209,9 @@ impl super::ResponseFormatter for Formatter {
 									}),
 								) => {
 									&b[..]
-										== &a[..]
+										== a.get(0..a.len() - 1).expect(
+											"non-root element while traversing trace result",
+										)
 								}
 								_ => unreachable!(),
 							}) {

--- a/vendor/client/evm-tracing/src/formatters/call_tracer.rs
+++ b/vendor/client/evm-tracing/src/formatters/call_tracer.rs
@@ -43,7 +43,7 @@ impl super::ResponseFormatter for Formatter {
 		for entry in listener.entries.iter() {
 			let mut result: Vec<Call> = entry
 				.into_iter()
-				.filter(|(_, it)| it.from.ne(&H160::zero()))
+				.filter(|(_, it)| it.from.ne(&H160::zero())) // Filters out calls to the ConversionRateController and other Precompiles
 				.map(|(_, it)| {
 					let from = it.from;
 					let trace_address = it.trace_address.clone();


### PR DESCRIPTION
## Description

The usage of the Runner for determining the transactions' conversion rate leads to create an additional entry in the transaction trace, and due to the implementation of moonbeam's `evm-tracer` was throwing an error. 

The solution is straightforward: filter out the additional entry provoked by the call to `ConversionRateController`

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
