### PR TITLE
fix: epochs missed are not restarted

### DIFF
--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -617,6 +617,8 @@ where
 		for validator in validators {
 			if !epoch_block_authors.contains(&validator) {
 				Self::increment_missed_block(validator);
+			} else {
+				EpochsMissed::<T>::remove(validator);
 			}
 		}
 

--- a/pallets/validator-set/src/lib.rs
+++ b/pallets/validator-set/src/lib.rs
@@ -615,10 +615,10 @@ where
 		}
 
 		for validator in validators {
-			if !epoch_block_authors.contains(&validator) {
-				Self::increment_missed_block(validator);
-			} else {
+			if epoch_block_authors.contains(&validator) {
 				EpochsMissed::<T>::remove(validator);
+			} else {
+				Self::increment_missed_block(validator);
 			}
 		}
 

--- a/pallets/validator-set/src/mock.rs
+++ b/pallets/validator-set/src/mock.rs
@@ -157,7 +157,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	});
 	validator_set::GenesisConfig::<Test> {
 		initial_validators: keys.iter().map(|x| x.1).collect::<Vec<_>>(),
-		max_epochs_missed: 1.into(),
+		max_epochs_missed: 2.into(),
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/pallets/validator-set/src/tests.rs
+++ b/pallets/validator-set/src/tests.rs
@@ -138,9 +138,9 @@ fn validator_misses_one_and_reconnects() {
 
 		let new_validators = <pallet::Validators<Test>>::get();
 
-		println!("{:?}", new_validators);
-
 		assert!(new_validators.contains(&authorities()[1].0));
+		// Safety check for ensuring that the validator id and index are correct
+		assert!(&authorities()[1].0.eq(&2u64));
 		assert!(EpochsMissed::<Test>::get(2) == U256::zero());
 	});
 }

--- a/pallets/validator-set/src/tests.rs
+++ b/pallets/validator-set/src/tests.rs
@@ -10,6 +10,7 @@ use crate::mock::{
 use frame_support::{assert_noop, assert_ok, pallet_prelude::*};
 use frame_system::RawOrigin;
 use sp_application_crypto::RuntimeAppPublic;
+use sp_core::U256;
 use sp_runtime::testing::UintAuthorityId;
 
 #[test]
@@ -117,6 +118,30 @@ fn validator_goes_off_and_reconnects() {
 		let new_validators = <pallet::Validators<Test>>::get();
 
 		assert!(new_validators.contains(&authorities()[1].0));
+	});
+}
+
+#[test]
+fn validator_misses_one_and_reconnects() {
+	new_test_ext().execute_with(|| {
+		for i in 0..SESSION_BLOCK_LENGTH {
+			mock_mine_block(1, i);
+		}
+
+		<pallet::Pallet<Test> as pallet_session::SessionManager<u64>>::end_session(0);
+
+		for i in 0..SESSION_BLOCK_LENGTH {
+			mock_mine_block(2, i + SESSION_BLOCK_LENGTH);
+		}
+
+		<pallet::Pallet<Test> as pallet_session::SessionManager<u64>>::end_session(1);
+
+		let new_validators = <pallet::Validators<Test>>::get();
+
+		println!("{:?}", new_validators);
+
+		assert!(new_validators.contains(&authorities()[1].0));
+		assert!(EpochsMissed::<Test>::get(2) == U256::zero());
 	});
 }
 


### PR DESCRIPTION
## Description

Reset epochs missed in the case a validator is included in the list of epoch actual validators.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
