### PR TITLE
fix: update zero gas transaction check and adjust test cases for fee …

### DIFF
--- a/primitives/runner/src/lib.rs
+++ b/primitives/runner/src/lib.rs
@@ -228,7 +228,7 @@ where
 
 		// Check if the transaction is a zero gas transaction.
 		// Or a Non-Transactional OP - Read/Call
-		let is_zero_gas_transaction: bool = maximum_gas_cost_with_base_fee == U256::zero();
+		let is_zero_gas_transaction: bool = custom_fee_info.actual_fee == U256::zero();
 
 		// Ensure the account has enough balance to pay for the transaction.
 		if !is_zero_gas_transaction {

--- a/primitives/runner/src/tests.rs
+++ b/primitives/runner/src/tests.rs
@@ -141,7 +141,10 @@ fn transaction_fee_log_emitted() {
 		let result = Runner::<Runtime, MockDNTFeeController, MockUserFeeTokenController>::call(
 			acc,
 			token_addr,
-			stbl_tools::eth::generate_calldata("transfer(recipient, amount)", &vec![acc.into(), H256::from_low_u64_be(100)]),
+			stbl_tools::eth::generate_calldata(
+				"transfer(recipient, amount)",
+				&vec![acc.into(), H256::from_low_u64_be(100)],
+			),
 			U256::from(0),
 			u64::MAX,
 			Some(U256::from(1)),
@@ -178,7 +181,7 @@ fn transaction_fee_log_not_emitted() {
 			stbl_tools::eth::generate_calldata("balanceOf(account)", &vec![acc.into()]),
 			U256::from(0),
 			u64::MAX,
-			Some(U256::from(1)),
+			Some(U256::from(0)),
 			None,
 			None,
 			vec![],

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-stability"),
 	impl_name: create_runtime_str!("node-stability"),
 	authoring_version: 1,
-	spec_version: 4,
+	spec_version: 5,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Description

Fixes EVM Runner for ZGT txns, where it's not required logs, withdraw fees, etc
The behavior was ok before due to the max_fee_per_gas = 0 making withdraw ZERO, but it was printing the BSR log, which wasn't expected.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
